### PR TITLE
Allows rake to run when bundle install --without development test

### DIFF
--- a/lib/metasploit_data_models/engine.rb
+++ b/lib/metasploit_data_models/engine.rb
@@ -2,13 +2,22 @@ require 'rails'
 
 module MetasploitDataModels
   class Engine < Rails::Engine
-
     # @see http://viget.com/extend/rails-engine-testing-with-rspec-capybara-and-factorygirl
     config.generators do |g|
       g.assets false
       g.fixture_replacement :factory_girl, :dir => 'spec/factories'
       g.helper false
       g.test_framework :rspec, :fixture => false
+    end
+
+    initializer 'metasploit_data_models.prepend_factory_path', :after => 'factory_girl.set_factory_paths' do
+      if defined? FactoryGirl
+        relative_definition_file_path = config.generators.options[:factory_girl][:dir]
+        definition_file_path = root.join(relative_definition_file_path)
+
+        # unshift so that Pro can modify mdm factories
+        FactoryGirl.definition_file_paths.unshift definition_file_path
+      end
     end
   end
 end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -4,5 +4,5 @@ module MetasploitDataModels
   # metasploit-framework/data/sql/migrate to db/migrate in this project, not all models have specs that verify the
   # migrations (with have_db_column and have_db_index) and certain models may not be shared between metasploit-framework
   # and pro, so models may be removed in the future.  Because of the unstable API the version should remain below 1.0.0
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -1,27 +1,26 @@
 # @note All options not specific to any given rake task should go in the .yardopts file so they are available to both
 #   the below rake tasks and when invoking `yard` from the command line
 
-require 'yard'
-require 'yard/rake/yardoc_task'
+if defined? YARD
+  namespace :yard do
+    YARD::Rake::YardocTask.new(:doc) do |t|
+      # --no-stats here as 'stats' task called after will print fuller stats
+      t.options = ['--no-stats']
 
-namespace :yard do
-  YARD::Rake::YardocTask.new(:doc) do |t|
-    # --no-stats here as 'stats' task called after will print fuller stats
-    t.options = ['--no-stats']
+      t.after = Proc.new {
+        Rake::Task['yard:stats'].execute
+      }
+    end
 
-    t.after = Proc.new {
-      Rake::Task['yard:stats'].execute
-    }
+    desc "Shows stats for YARD Documentation including listing undocumented modules, classes, constants, and methods"
+    task :stats => :environment do
+      stats = YARD::CLI::Stats.new
+      stats.run('--compact', '--list-undoc')
+    end
   end
 
-  desc "Shows stats for YARD Documentation including listing undocumented modules, classes, constants, and methods"
-  task :stats => :environment do
-    stats = YARD::CLI::Stats.new
-    stats.run('--compact', '--list-undoc')
-  end
+  # @todo Figure out how to just clone description from yard:doc
+  desc "Generate YARD documentation"
+  # allow calling namespace to as a task that goes to default task for namespace
+  task :yard => ['yard:doc']
 end
-
-# @todo Figure out how to just clone description from yard:doc
-desc "Generate YARD documentation"
-# allow calling namespace to as a task that goes to default task for namespace
-task :yard => ['yard:doc']

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -2,7 +2,7 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-Bundler.require
+Bundler.require(*Rails.groups)
 # require the engine being tested.  In a non-dummy app this would be handled by the engine's gem being in the Gemfile
 # for real app and Bundler.require requiring the gem.
 require 'metasploit_data_models'


### PR DESCRIPTION
[#45771305]

MetasploitDataModels being a Rails::Engine means its lib/tasks folder is
included in the rake tasks loaded by Pro.  The problem with this was
that lib/tasks/yard.rake always assumed YARD was available, but it's not
when building the bundles since Pro is bundled --without cucumber
development test.  Guard the yard namespace with defined? YARD and make
sure YARD is loaded when needed by having the dummy app in spec/dummy
pass Rails.groups to Bundler.require so that more than just the default
group is loaded.

Since that pulls in factory_girl_rails, the spec/factories in
metasploit_data_models weren't being found since it was looking for
spec/factory under spec/dummy, so copy the initializer from Pro to
inject the MetasploitDataModels factories as an initializer
'metasploit_data_models.prepend_factory_path' in
MetasploitDataModels::Engine that both spec/dummy and Pro can use.
