### PR TITLE
Allow 0 for Mdm::WebVuln#confidence

### DIFF
--- a/app/models/mdm/web_vuln.rb
+++ b/app/models/mdm/web_vuln.rb
@@ -15,9 +15,8 @@ class Mdm::WebVuln < ActiveRecord::Base
   # CONSTANTS
   #
 
-  # A percentage {#confidence} that the vulnerability is real and not a false positive.  0 is not allowed because there
-  # shouldn't be an {Mdm::WebVuln} record if there is 0% {#confidence} in the the finding.
-  CONFIDENCE_RANGE = 1 .. 100
+  # A percentage {#confidence} that the vulnerability is real and not a false positive.
+  CONFIDENCE_RANGE = 0 .. 100
 
   # Default value for {#params}
   DEFAULT_PARAMS = []

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -4,5 +4,5 @@ module MetasploitDataModels
   # metasploit-framework/data/sql/migrate to db/migrate in this project, not all models have specs that verify the
   # migrations (with have_db_column and have_db_index) and certain models may not be shared between metasploit-framework
   # and pro, so models may be removed in the future.  Because of the unstable API the version should remain below 1.0.0
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end

--- a/spec/app/models/mdm/web_vuln_spec.rb
+++ b/spec/app/models/mdm/web_vuln_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Mdm::WebVuln do
   let(:confidence_range) do
-    1 .. 100
+    0 .. 100
   end
 
   let(:default_params) do

--- a/spec/factories/mdm/web_vulns.rb
+++ b/spec/factories/mdm/web_vulns.rb
@@ -25,8 +25,8 @@ FactoryGirl.define do
   end
 
   sequence :mdm_web_vuln_confidence do |n|
-    # range is from 1 to 100 so do mod 99 (0 - 99 range) and add 1 to get correct range
-    (n % 99) + 1
+    # range is from 0 to 100
+    n % 101
   end
 
   method_count = Mdm::WebVuln::METHODS.length


### PR DESCRIPTION
[#45816713]

I misread
https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/db.rb#L2414
and thought confidence had to be > 0 instead of it could not be < 0, so
I had made confidence range 1 .. 100 instead of the correct 0 .. 100.
