### PR TITLE
Ruby 2.0.0 Compatibility: Adding the binary encoding declaration.

### DIFF
--- a/db/migrate/20110422000000_convert_binary.rb
+++ b/db/migrate/20110422000000_convert_binary.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 class ConvertBinary < ActiveRecord::Migration
 
 


### PR DESCRIPTION
When using Ruby 2.0.0p0 on OS X, a db:migrate will error out with faulty encoding without this declaration. Adding it fixes that.
