### PR TITLE
Rewire the migration to ignore orphan DB objects

### DIFF
--- a/db/migrate/20130423211152_add_creds_counter_cache.rb
+++ b/db/migrate/20130423211152_add_creds_counter_cache.rb
@@ -7,7 +7,12 @@ class AddCredsCounterCache < ActiveRecord::Migration
     Mdm::Cred.all.each {|c| cred_service_ids << c.service_id}
     cred_service_ids.each do |service_id|
       #Mdm::Host.reset_counters(Mdm::Service.find(service_id).host.id, :creds)
-      host = Mdm::Service.find(service_id).host
+      begin
+        host = Mdm::Service.find(service_id).host
+      rescue
+        next
+      end
+      next if host.nil? # This can happen with orphan creds/services
       host.cred_count = host.creds.count
       host.save
     end


### PR DESCRIPTION
Legacy databases can contain orphan creds and services.
AddCredsCounterCache iterates through all creds, finding their
associated services, and the host associated with that service.
host.creds.count is then called to set the counter cache. Orphan
objects in the DB can cause the chain to call :host on a nil
service or :creds on a nil host.

This artifact showed up in an older install of framework which
was behind on updates. Not a common event, but should be handled
without forcing the user to delete what may be useful information.
