### PR TITLE
Require stance only for auxiliary and exploit

### DIFF
--- a/app/models/mdm/module/detail.rb
+++ b/app/models/mdm/module/detail.rb
@@ -167,9 +167,10 @@ class Mdm::Module::Detail < ActiveRecord::Base
   #   @return [String]
 
   # @!attribute [rw] stance
-  #   Whether the module is active or passive.
+  #   Whether the module is active or passive.  `nil` if the {#mtype module type} does not
+  #   {#supports_stance? support stances}.
   #
-  #   @return ['active', 'passive']
+  #   @return ['active', 'passive', nil]
 
   #
   # Validations
@@ -193,6 +194,7 @@ class Mdm::Module::Detail < ActiveRecord::Base
   validates :refname, :presence => true
   validates :stance,
             :inclusion => {
+                :if => :supports_stance?,
                 :in => STANCES
             }
 
@@ -274,6 +276,23 @@ class Mdm::Module::Detail < ActiveRecord::Base
   # @return [false] if save was unsuccessful.
   def add_target(index, name)
     self.targets.build(:index => index, :name => name).save
+  end
+
+  # Returns whether this module supports a {#stance}.  Only modules with {#mtype} `'auxiliary'` and `'exploit'` support
+  # a non-nil {#stance}.
+  #
+  # @return [true] if {#mtype} is `'auxiliary'` or `'exploit'`
+  # @return [false] otherwise
+  # @see https://github.com/rapid7/metasploit-framework/blob/a6070f8584ad9e48918b18c7e765d85f549cb7fd/lib/msf/core/db_manager.rb#L423
+  # @see https://github.com/rapid7/metasploit-framework/blob/a6070f8584ad9e48918b18c7e765d85f549cb7fd/lib/msf/core/db_manager.rb#L436
+  def supports_stance?
+    supports_stance = false
+
+    if ['auxiliary', 'exploit'].include? mtype
+      supports_stance = true
+    end
+
+    supports_stance
   end
 
   ActiveSupport.run_load_hooks(:mdm_module_detail, self)

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -4,5 +4,5 @@ module MetasploitDataModels
   # metasploit-framework/data/sql/migrate to db/migrate in this project, not all models have specs that verify the
   # migrations (with have_db_column and have_db_index) and certain models may not be shared between metasploit-framework
   # and pro, so models may be removed in the future.  Because of the unstable API the version should remain below 1.0.0
-  VERSION = '0.14.2'
+  VERSION = '0.14.3'
 end

--- a/spec/factories/mdm/module/details.rb
+++ b/spec/factories/mdm/module/details.rb
@@ -17,7 +17,14 @@ FactoryGirl.define do
     rank { generate :mdm_module_detail_rank }
     refname { generate :mdm_module_detail_refname }
     fullname { "#{mtype}/#{refname}" }
-    stance { generate :mdm_module_detail_stance }
+
+    stance {
+      if supports_stance?
+        generate :mdm_module_detail_stance
+      else
+        nil
+      end
+    }
 
     file {
       type_directory = Mdm::Module::Detail::DIRECTORY_BY_TYPE[mtype]

--- a/spec/support/shared/examples/mdm/module/detail/does_not_support_stance_with_mtype.rb
+++ b/spec/support/shared/examples/mdm/module/detail/does_not_support_stance_with_mtype.rb
@@ -1,0 +1,20 @@
+shared_examples_for 'Mdm::Module::Detail does not support stance with mtype' do |mtype|
+  context "with #{mtype.inspect}" do
+    # define as a let so that lets from outer context can access option to set detail.
+    let(:mtype) do
+      mtype
+    end
+
+    it 'should return false for supports_stance?' do
+      detail.supports_stance?.should be_false
+    end
+
+    context 'with nil stance' do
+      let(:stance) do
+        nil
+      end
+
+      it { should be_valid }
+    end
+  end
+end

--- a/spec/support/shared/examples/mdm/module/detail/supports_stance_with_mtype.rb
+++ b/spec/support/shared/examples/mdm/module/detail/supports_stance_with_mtype.rb
@@ -1,0 +1,36 @@
+shared_examples_for 'Mdm::Module::Detail supports stance with mtype' do |mtype|
+  context "with #{mtype.inspect}" do
+    # define as a let so that lets from outer context can access option to set detail.
+    let(:mtype) do
+      mtype
+    end
+
+    it 'should return true for supports_stance?' do
+      detail.supports_stance?.should be_true
+    end
+
+    context 'with nil stance' do
+      let(:stance) do
+        nil
+      end
+
+      it { should be_invalid }
+    end
+
+    context "with 'aggresive' stance" do
+      let(:stance) do
+        'aggressive'
+      end
+
+      it { should be_valid }
+    end
+
+    context "with 'passive' stance" do
+      let(:stance) do
+        'passive'
+      end
+
+      it { should be_valid }
+    end
+  end
+end


### PR DESCRIPTION
[#49858419]
[SEERM #7958]

Mdm::Module::Detail#stance should only be validated for inclusion in
Mdm::Module::Detail::STANCES if Mdm::Module::Detail#mtype is 'auxiliary'
or 'exploit' because in metasploit-framework, only those types of
modules use stances.  Mdm::Module::Detail#stance being `nil` for other
types is not enforced in case there are incorrect modules out there: its
better that the cache work.
