### PR TITLE
Removes validation of pname

### DIFF
--- a/app/models/mdm/web_vuln.rb
+++ b/app/models/mdm/web_vuln.rb
@@ -123,7 +123,6 @@ class Mdm::WebVuln < ActiveRecord::Base
   validates :name, :presence => true
   validates :params, :parameters => true
   validates :path, :presence => true
-  validates :pname, :presence => true
   validates :proof, :presence => true
   validates :risk,
             :inclusion => {

--- a/db/migrate/20130717150737_remove_pname_validation.rb
+++ b/db/migrate/20130717150737_remove_pname_validation.rb
@@ -1,0 +1,7 @@
+class RemovePnameValidation < ActiveRecord::Migration
+
+  def change
+		change_column :web_vulns, :pname, :text, :null => true
+  end
+
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -4,5 +4,5 @@ module MetasploitDataModels
   # metasploit-framework/data/sql/migrate to db/migrate in this project, not all models have specs that verify the
   # migrations (with have_db_column and have_db_index) and certain models may not be shared between metasploit-framework
   # and pro, so models may be removed in the future.  Because of the unstable API the version should remain below 1.0.0
-  VERSION = '0.16.5'
+  VERSION = '0.16.6'
 end

--- a/spec/app/models/mdm/web_vuln_spec.rb
+++ b/spec/app/models/mdm/web_vuln_spec.rb
@@ -68,7 +68,7 @@ describe Mdm::WebVuln do
       it { should have_db_column(:params).of_type(:text).with_options(:null => false) }
       it { should have_db_column(:path).of_type(:text).with_options(:null => false) }
       it { should have_db_column(:payload).of_type(:text) }
-      it { should have_db_column(:pname).of_type(:text).with_options(:null => false) }
+      it { should have_db_column(:pname).of_type(:text) }
       it { should have_db_column(:proof).of_type(:binary).with_options(:null => false) }
       it { should have_db_column(:query).of_type(:text) }
       it { should have_db_column(:request).of_type(:binary) }
@@ -278,7 +278,6 @@ describe Mdm::WebVuln do
       end
     end
 
-    it { should validate_presence_of :pname }
     it { should validate_presence_of :proof }
     it { should ensure_inclusion_of(:risk).in_range(risk_range) }
     it { should validate_presence_of :web_site }

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130604145732) do
+ActiveRecord::Schema.define(:version => 20130717150737) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -546,7 +546,7 @@ ActiveRecord::Schema.define(:version => 20130604145732) do
     t.text     "path",                        :null => false
     t.string   "method",      :limit => 1024, :null => false
     t.text     "params",                      :null => false
-    t.text     "pname",                       :null => false
+    t.text     "pname"
     t.integer  "risk",                        :null => false
     t.string   "name",        :limit => 1024, :null => false
     t.text     "query"


### PR DESCRIPTION
https://dev.metasploit.com/redmine/issues/8119
- [x] Specs pass for metasploit_data_models
- [x] Specs pass on MSF PR: https://github.com/rapid7/metasploit-framework/pull/2112
- [x] Specs pass on Pro PR: https://github.com/rapid7/pro/pull/877
- [x] Merge this PR
- [x] Locally, in mdm checkout, pull master and `rake release` to publish metasploit_data_models to rubygems
- [x] Add 'Jenkins test this please' to Pro PR: https://github.com/rapid7/pro/pull/877
- [x] For MSF, you will need to sign into Travis CI and trigger a restart build on the build that failed. You will need to be an admin on https://travis-ci.org/rapid7/metasploit-framework or ask one (Luke, Sam, Brandon)
- [x] MSF passes Travis CI
- [x] Jenkins passes Pro
- [x] Merge MSF PR: https://github.com/rapid7/metasploit-framework/pull/2112
- [x] Merge Pro PR: https://github.com/rapid7/pro/pull/877
- [x] [Release the Java version](https://github.com/rapid7/pro/wiki/MDM-gem#java-gem)
