### PR TITLE
Import architectures from rex constants

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -14,13 +14,16 @@ class Mdm::Host < ActiveRecord::Base
       'cbea',
       'cbea64',
       'cmd',
+      'dalvik',
       'java',
       'mips',
       'mipsbe',
       'mipsle',
+      'nodejs',
       'php',
       'ppc',
       'ppc64',
+      'python',
       'ruby',
       'sparc',
       'tty',
@@ -29,6 +32,7 @@ class Mdm::Host < ActiveRecord::Base
       'x86',
       'x86_64'
   ]
+
 
   # Fields searched for the search scope
   SEARCH_FIELDS = [


### PR DESCRIPTION
We've been adding these to the framework side as our payload arsenal grows.
This updates Mdm architectures list to match those present in rex/constants