### PR TITLE
Overhaul of normalize_os() with Recog support

### DIFF
--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activesupport'
 
   # os fingerprinting
-  s.add_runtime_dependency 'recog'
+  s.add_runtime_dependency 'recog', '~> 1.0'
 
   s.add_runtime_dependency 'metasploit-concern', '~> 0.1.0'
   s.add_runtime_dependency 'metasploit-model', '~> 0.26.1'


### PR DESCRIPTION
This reimplements MDM::Host.normalize_os() in order to leverage the [Recog](https://github.com/rapid7/recog) fingerprint database. The changes are backwards-compatible, but they do change how os_name and os_flavor fields are handled. Previously, an OS match of "Windows XP" would be split into an os_name of "Windows" and an os_flavor of "XP". The new code would treat os_name as "Windows XP" and save os_flavor for the product edition (Home, Pro, etc). This change is cosmetic and mostly transparent given how most callers treat these fields (they merge them together for display). [Framework PR](https://github.com/rapid7/metasploit-framework/pull/3373)  
