### PR TITLE
Fix gem version to support rubygems < 2.1

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -25,7 +25,19 @@ module MetasploitDataModels
 
       version
     end
+
+    # The full gem version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
+    # {http://guides.rubygems.org/specification-reference/#version RubyGems versioning} format.
+    #
+    # @return [String] '{MAJOR}.{MINOR}.{PATCH}' on master.  '{MAJOR}.{MINOR}.{PATCH}.{PRERELEASE}' on any branch
+    #   other than master.
+    def self.gem
+      full.gsub('-', '.pre.')
+    end
   end
+
+  # @see Version.gem
+  GEM_VERSION = Version.gem
 
   # @see Version.full
   VERSION = Version.full

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -4,7 +4,7 @@ require 'metasploit_data_models/version'
 
 Gem::Specification.new do |s|
   s.name        = 'metasploit_data_models'
-  s.version     = MetasploitDataModels::VERSION
+  s.version     = MetasploitDataModels::GEM_VERSION
   s.authors     = [
       'Samuel Huckins',
       'Luke Imhoff',


### PR DESCRIPTION
https://jira.tor.rapid7.com/browse/MSP-10714
## Verification Steps
- [x] `gem update --system 1.8.23`
- [x] `bundle`
- [x] VERIFY: bundle completes successfully
- [x] VERIFY: `rake spec` completes successfully
## Land
- [x] Merge this PR
- [x] Remove `PRERELEASE` constant and comment from `lib/metasploit_data_models/version.rb`.  Commit and push.
