### PR TITLE
add logins relation to service

### DIFF
--- a/app/models/mdm/service.rb
+++ b/app/models/mdm/service.rb
@@ -25,6 +25,16 @@ class Mdm::Service < ActiveRecord::Base
            dependent: :destroy,
            inverse_of: :service
 
+  # @!attribute logins
+  #   Credentials gathered from this service.
+  #
+  #   @return [ActiveRecord::Relation<Metasploit::Credential::Login>]
+  has_many :logins,
+           class_name: 'Metasploit::Credential::Login',
+           dependent: :destroy,
+           inverse_of: :service
+
+
   # @!attribute exploit_attempts
   #   Exploit attempts against this service.
   #


### PR DESCRIPTION
Prevents creds command from throwing a stack trace complaining about lack of relation for Mdm::Service :logins and Metasploit::Credential::Login :service.

```
[-] Error while running command creds: Could not find the inverse association for service (:logins in Mdm::Service)
```

After manually pry-ing the class and inserting the AssociationReflection everything works as expected.
