### PR TITLE
Containerized build and other build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ rvm:
   - '1.9.3'
   - '2.0'
   - '2.1'
-  - 'jruby-19mode'
+  - jruby-1.7.17
   - 'rbx-2.2'
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
   - rake db:setup
+cache: bundler
 language: ruby
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,9 @@ before_script:
   - bundle exec rake db:setup
 cache: bundler
 language: ruby
-matrix:
-  allow_failures:
-    # Rubinius.mri_backtrace primitive failed (PrimitiveFailure)
-    - rvm: 'rbx-2.2'
 rvm:
   - '1.9.3'
   - '2.0'
   - '2.1'
   - jruby-1.7.17
-  - 'rbx-2.2'
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ rvm:
   - '2.1'
   - 'jruby-19mode'
   - 'rbx-2.2'
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
-  - rake db:setup
+  - bundle exec rake db:setup
 cache: bundler
 language: ruby
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ before_script:
 cache: bundler
 language: ruby
 rvm:
-  - '1.9.3'
-  - '2.0'
-  - '2.1'
+  - 1.9.3
+  - 2.0
+  - 2.1
   - jruby-1.7.17
 sudo: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,5 @@
-#!/usr/bin/env rake
-begin
-  require 'bundler/setup'
-rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
-end
+require 'bundler/gem_tasks'
+require 'bundler/setup'
 
 print_without = false
 APP_RAKEFILE = File.expand_path('../spec/dummy/Rakefile', __FILE__)

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 21
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 3
+    PATCH = 4
+    # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+    PRERELEASE = 'containerized'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
MSP-11929

Turn on containerized builds using `sudo: false` for faster build startup.  Turn on bundle caching with `cache: bundler` for faster build install.  Replace `jruby-19mode` with `jruby-1.7.17` to work around https://github.com/travis-ci/travis-ci/issues/3067 and https://github.com/wayneeseguin/rvm/issues/3242, which is unrelated to this chore, but a currently problem with travis-ci's rvm install and so would block any builds.  Fix bundler requires in `Rakefile` to make it work when the bundle is uncached.  `bundle exec rake db:setup` instead of just `rake db:setup` for bundler cache compatibility.  Remove rbx-2.2 to speed up overall build time as the rbx-2.2 build never succeeds and so just eats up job slots.  Clean up quoting in .travis.yml for compatibility with travis lint.

# Verification
- [ ] Look at the [build log](https://travis-ci.org/rapid7/metasploit_data_models/jobs/45549951)
- [ ] VERIFY containerized message in log: `This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.`
- [ ] VERIFY bundler cache in log: `adding /home/travis/build/rapid7/metasploit_data_models/vendor/bundle to cache`

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## Version

- `PATCH` has already been incremented

## Rubygems

- No release to rubygems as this is a build infrastructure change only