### PR TITLE
Use metasploit-model with metasploit-cache extracted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,13 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in metasploit_data_models.gemspec
 gemspec
 
+gem 'metasploit-cache',
+    github: 'rapid7/metasploit-cache',
+    ref: 'f7a888beaac50d9d9c8ba66c0563ea1ac048f07a'
+gem 'metasploit-model',
+    github: 'rapid7/metasploit-model',
+    ref: '8794a1313d58fc588fa0fd5994cd1a8c150536f0'
+
 group :development do
   # embed ERDs on index, namespace Module and Class<ActiveRecord::Base> pages
   gem 'yard-metasploit-erd', '~> 0.0.2'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 gem 'metasploit-model',
     github: 'rapid7/metasploit-model',
-    ref: '8794a1313d58fc588fa0fd5994cd1a8c150536f0'
+    ref: 'ee4d06009811c21c36ace781b27509f816ef7fee'
 
 group :development do
   # embed ERDs on index, namespace Module and Class<ActiveRecord::Base> pages

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in metasploit_data_models.gemspec
 gemspec
 
-gem 'metasploit-cache',
-    github: 'rapid7/metasploit-cache',
-    ref: 'f7a888beaac50d9d9c8ba66c0563ea1ac048f07a'
 gem 'metasploit-model',
     github: 'rapid7/metasploit-model',
     ref: '8794a1313d58fc588fa0fd5994cd1a8c150536f0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in metasploit_data_models.gemspec
 gemspec
 
-gem 'metasploit-model',
-    github: 'rapid7/metasploit-model',
-    ref: 'ee4d06009811c21c36ace781b27509f816ef7fee'
-
 group :development do
   # embed ERDs on index, namespace Module and Class<ActiveRecord::Base> pages
   gem 'yard-metasploit-erd', '~> 0.0.2'

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 21
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 3
+    PATCH = 4
+    # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+    PRERELEASE = 'extract-cache-from-metasploit-model'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'recog', '~> 1.0'
 
   s.add_runtime_dependency 'metasploit-concern', '~> 0.3.0'
-  s.add_runtime_dependency 'metasploit-model', '= 0.29.0.pre.extract.pre.cache.pre.from.pre.metasploit.pre.model'
+  s.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   s.add_runtime_dependency 'railties', '< 4.0.0'
 
   # arel-helpers: Useful tools to help construct database queries with ActiveRecord and Arel.

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'recog', '~> 1.0'
 
   s.add_runtime_dependency 'metasploit-concern', '~> 0.3.0'
-  s.add_runtime_dependency 'metasploit-model', '~> 0.28.0'
+  s.add_runtime_dependency 'metasploit-model', '= 0.29.0.pre.extract.pre.cache.pre.from.pre.metasploit.pre.model'
   s.add_runtime_dependency 'railties', '< 4.0.0'
 
   # arel-helpers: Useful tools to help construct database queries with ActiveRecord and Arel.


### PR DESCRIPTION
MSP-11141

Test that metasploit-model with metasploit-cache extracted, although it has an incompatible semantic version produces a compatible metasploit_data_models because nothing in metasploit_data_models depends on the code extracted to metasploit-cache.

# Verification Steps

## `metasploit-model`
- [x] Complete [Verification Steps for `metasploit-model`](https://github.com/rapid7/metasploit-model/pull/31#issue-53192272)

## `metasploit_data_models`

- [x] `bundle install`

### `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Pre-merge Steps

## Updating metasploit-model
- [x] Complete [Release for `metasploit-model`](https://github.com/rapid7/metasploit-model/pull/31#issue-53192272)
- [x] Change the `metasploit-model` version in `metasploit-cache.gemspec` to released version: `spec.add_runtime_dependency 'metasploit-model', '~> 0.29.0'`
- [x] Remove `metasploit-model` from `Gemfile`.
- [x] `rm Gemfile.lock`
- [x] `bundle install`

### Test changes
- [x] `rake spec`
- [x] VERIFY no failures

### Commit & Push update
- [x] `git commit -a`
- [x] `git push`

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## Version

### Compatible changes

- Incremented [`PATCH`](lib/metasploit_data_models/version.rb).

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`


# Downstream changes

## `metasploit-credential`
- [ ] Complete [`Pre-merge steps Updating metasploit_data_models`](https://github.com/rapid7/metasploit-credential/pull/86#issue-53198346)

## `metasploit-framework`
- [ ] Complete [`Pre-merge steps Updating metasploit_data_models`](https://github.com/rapid7/metasploit-framework/pull/4500#issue-53205565)