### PR TITLE
MSP-12011: Convert find(:all)

### DIFF
--- a/db/migrate/20100819123300_migrate_cred_data.rb
+++ b/db/migrate/20100819123300_migrate_cred_data.rb
@@ -4,7 +4,7 @@ class MigrateCredData < ActiveRecord::Migration
 		begin # Wrap the whole thing in a giant rescue.
 		skipped_notes = []
 		new_creds = []
-		Mdm::Note.find(:all).each do |note|
+		Mdm::Note.all.each do |note|
 			next unless note.ntype[/^auth\.(.*)/]
 			service_name = $1
 			if !service_name
@@ -135,7 +135,7 @@ class MigrateCredData < ActiveRecord::Migration
 		end
 
 		say "Deleting migrated auth notes."
-		Mdm::Note.find(:all).each do |note|
+		Mdm::Note.all.each do |note|
 			next unless note.ntype[/^auth\.(.*)/]
 			note.delete
 		end

--- a/db/migrate/20110422000000_convert_binary.rb
+++ b/db/migrate/20110422000000_convert_binary.rb
@@ -27,10 +27,10 @@ class ConvertBinary < ActiveRecord::Migration
 		add_column :web_vulns, :request, :binary
 		add_column :web_vulns, :proof, :binary
 
-		WebPage.find(:all).each { |r| r.body = r.body_text; r.save! }
-		WebPage.find(:all).each { |r| r.request = r.request_text; r.save! }
-		WebVuln.find(:all).each { |r| r.proof = r.proof_text; r.save! }
-		WebVuln.find(:all).each { |r| r.request = r.request_text; r.save! }
+		WebPage.all.each { |r| r.body = r.body_text; r.save! }
+		WebPage.all.each { |r| r.request = r.request_text; r.save! }
+		WebVuln.all.each { |r| r.proof = r.proof_text; r.save! }
+		WebVuln.all.each { |r| r.request = r.request_text; r.save! }
 
 		remove_column :web_pages, :body_text
 		remove_column :web_pages, :request_text
@@ -55,10 +55,10 @@ class ConvertBinary < ActiveRecord::Migration
 		add_column :web_vulns, :request, :text
 		add_column :web_vulns, :proof, :text
 
-		WebPage.find(:all).each { |r| r.body = bfilter(r.body_binary); r.save! }
-		WebPage.find(:all).each { |r| r.request = bfilter(r.request_binary); r.save! }
-		WebVuln.find(:all).each { |r| r.proof = bfilter(r.proof_binary); r.save! }
-		WebVuln.find(:all).each { |r| r.request = bfilter(r.request_binary); r.save! }
+		WebPage.all.each { |r| r.body = bfilter(r.body_binary); r.save! }
+		WebPage.all.each { |r| r.request = bfilter(r.request_binary); r.save! }
+		WebVuln.all.each { |r| r.proof = bfilter(r.proof_binary); r.save! }
+		WebVuln.all.each { |r| r.request = bfilter(r.request_binary); r.save! }
 
 		remove_column :web_pages, :body_binary
 		remove_column :web_pages, :request_binary

--- a/db/migrate/20110513143900_track_successful_exploits.rb
+++ b/db/migrate/20110513143900_track_successful_exploits.rb
@@ -12,7 +12,7 @@ class TrackSuccessfulExploits < ActiveRecord::Migration
 
 		# Migrate existing exploited_hosts entries
 
-		ExploitedHost.find(:all).select {|x| x.name}.each do |exploited_host|
+		ExploitedHost.all.select {|x| x.name}.each do |exploited_host|
 			next unless(exploited_host.name =~ /^(exploit|auxiliary)\//)
 			vulns = Vuln.find_all_by_name_and_host_id(exploited_host.name, exploited_host.host_id)
 			next if vulns.empty?

--- a/db/migrate/20110517160800_rename_and_prune_nessus_vulns.rb
+++ b/db/migrate/20110517160800_rename_and_prune_nessus_vulns.rb
@@ -6,7 +6,7 @@ class RenameAndPruneNessusVulns < ActiveRecord::Migration
 	# No table changes, just vuln renaming to drop the NSS id
 	# from those vulns that have it and a descriptive name.
 	def self.up
-		Vuln.find(:all).each do |v|
+		Vuln.all.each do |v|
 			if v.name =~ /^NSS-0?\s*$/
 				v.delete
 				next

--- a/db/migrate/20111011110000_add_display_name_to_reports_table.rb
+++ b/db/migrate/20111011110000_add_display_name_to_reports_table.rb
@@ -9,7 +9,7 @@ class AddDisplayNameToReportsTable < ActiveRecord::Migration
 
 		# Migrate to have a default name.
 		
-		Report.find(:all).each do |report|
+		Report.all.each do |report|
 			rtype = report.rtype.to_s =~ /^([A-Z0-9]+)\x2d/i ? $1 : "AUDIT"
 			default_name = rtype[0,57].downcase.capitalize + "-" + report.id.to_s[0,5]
 			report.name = default_name

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 3
 
-    PRERELEASE = 'rails-4.0'
+    PRERELEASE = 'convert-find-all'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
This PR updates the #find(:all) to rails 4 #where or #all syntax.

For example:

Old syntax: `Mdm::Note.find(:all).each do |note|`
New syntax: `Mdm::Note.all.each do |note|`

Old syntax: `Mdm::Task.find(:all, :conditions => { :completed_at => nil }).each do |t|`
New syntax: `Mdm::Task.where(completed_at: `nil).each do |t|`

Old syntax: `all_hosts = myworkspace.hosts.find(:all)`
New syntax: `all_hosts = myworkspace.hosts`

# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`