### PR TITLE
MSP-11643: Correction to service uniqueness on host validation

### DIFF
--- a/app/models/mdm/service.rb
+++ b/app/models/mdm/service.rb
@@ -222,14 +222,19 @@ class Mdm::Service < ActiveRecord::Base
                 in: PROTOS
             }
 
-  validates :host_id,
-            uniqueness: {
-              message: 'already has a service with this port and proto',
-              scope: [
-                :port,
-                :proto
-              ]
-            }
+  validate :uniq_port_proto_per_host
+
+  # Custom validation to ensure that the combination of port and protocol
+  # for a service doesn't already exist for the same host.
+  def uniq_port_proto_per_host
+    no_dupes = Mdm::Service.where(host_id: host.id, port: port, proto: proto).blank?
+    error_msg = 'This host already has a service with this port and protocol.'
+
+    unless no_dupes
+      errors.add(:port, error_msg)
+      errors.add(:proto, error_msg)
+    end
+  end
 
   #
   # Class Methods

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -7,7 +7,6 @@ module MetasploitDataModels
     MINOR = 22
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 2
-    PRERELEASE = 'correcting-svc-uniq-validation'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,8 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 22
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 1
+    PATCH = 2
+    PRERELEASE = 'correcting-svc-uniq-validation'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
MSP-11643

We now verify the combination of port and protocol within the scope of the parent host ID, versus verifying host_id is unique within the scope of port/proto. This allows the validation messages to have somewhere to appear in the service add window, associated with the port and protocol fields.

## Steps to verify
- [x] Change your Pro Gemfile metasploit_data_models (L52), to point to your MDM checkout (:path)
- [x] In pro, bundle install, start foreman
- [x] Analysis -> Hosts -> Any single host -> services tab
- [x] Add a service, e.g. SSH, 22, TCP
- [x] Add the same thing again
- [x] You should see 'This host already has a service with this port and protocol.' displayed by the port field

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release
## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1.5@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`
