### PR TITLE
Revert "MSP-11643: Correction to service uniqueness on host validation"

### DIFF
--- a/app/models/mdm/service.rb
+++ b/app/models/mdm/service.rb
@@ -222,19 +222,14 @@ class Mdm::Service < ActiveRecord::Base
                 in: PROTOS
             }
 
-  validate :uniq_port_proto_per_host
-
-  # Custom validation to ensure that the combination of port and protocol
-  # for a service doesn't already exist for the same host.
-  def uniq_port_proto_per_host
-    no_dupes = Mdm::Service.where(host_id: host.id, port: port, proto: proto).blank?
-    error_msg = 'This host already has a service with this port and protocol.'
-
-    unless no_dupes
-      errors.add(:port, error_msg)
-      errors.add(:proto, error_msg)
-    end
-  end
+  validates :host_id,
+            uniqueness: {
+              message: 'already has a service with this port and proto',
+              scope: [
+                :port,
+                :proto
+              ]
+            }
 
   #
   # Class Methods

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,7 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 22
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 2
+    PATCH = 1
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,7 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 22
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 1
+    PATCH = 3
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
Reverts rapid7/metasploit_data_models#91, due to unforeseen issues with the fix.

Follow the post-release steps in #91.