### PR TITLE
MSP-12016: Convert #find_or_create_by

### DIFF
--- a/app/models/mdm/workspace.rb
+++ b/app/models/mdm/workspace.rb
@@ -95,7 +95,7 @@ class Mdm::Workspace < ActiveRecord::Base
   end
 
   def self.default
-    find_or_create_by_name(DEFAULT)
+    where(name: DEFAULT).first_or_create
   end
 
   def default?

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 3
 
-    PRERELEASE = 'rails-4.0'
+    PRERELEASE = 'convert-find-or-create-by'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
This PR updates the #find_or_create_by to rails 4 #where().first_or_create syntax.

For example:

Old syntax: `Apps::AppCategory.find_or_create_by_name!(cat)`
New syntax: `Apps::AppCategory.where(name: cat).first_or_create!`

Old syntax: `workspace = Mdm::Workspace.find_or_create_by_name(WORKSPACE, owner_id: user.id)`
New syntax: `workspace = Mdm::Workspace.where(name: WORKSPACE).first_or_create(owner_id: user.id)`

# Verification Steps

- [ ] `bundle install`
- [ ] `rake spec`
- [ ] VERIFY no failures
- [ ] Verify no other instances of #find_or_create_by_X

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`