### PR TITLE
MSP-12014: Convert find_all_by_X to Rails 4 compatible syntax

### DIFF
--- a/db/migrate/20110317144932_add_session_table.rb
+++ b/db/migrate/20110317144932_add_session_table.rb
@@ -50,13 +50,13 @@ class AddSessionTable < ActiveRecord::Migration
  		# Migrate session data from events table
  		#
 
- 		close_events = Event.find_all_by_name("session_close")
- 		open_events  = Event.find_all_by_name("session_open")
+ 		close_events = Event.where(name: "session_close")
+ 		open_events  = Event.where(name: "session_open")
 
- 		command_events  = Event.find_all_by_name("session_command")
- 		output_events   = Event.find_all_by_name("session_output")
- 		upload_events   = Event.find_all_by_name("session_upload")
- 		download_events = Event.find_all_by_name("session_download")
+ 		command_events  = Event.where(name: "session_command")
+ 		output_events   = Event.where(name: "session_output")
+ 		upload_events   = Event.where(name: "session_upload")
+ 		download_events = Event.where(name: "session_download")
 
  		open_events.each do |o|
  			c = close_events.find { |e| e.info[:session_uuid] == o.info[:session_uuid] }

--- a/db/migrate/20110513143900_track_successful_exploits.rb
+++ b/db/migrate/20110513143900_track_successful_exploits.rb
@@ -14,7 +14,7 @@ class TrackSuccessfulExploits < ActiveRecord::Migration
 
 		ExploitedHost.find(:all).select {|x| x.name}.each do |exploited_host|
 			next unless(exploited_host.name =~ /^(exploit|auxiliary)\//)
-			vulns = Vuln.find_all_by_name_and_host_id(exploited_host.name, exploited_host.host_id)
+			vulns = Vuln.where(name: exploited_host.name, host_id: exploited_host.host_id)
 			next if vulns.empty?
 			vulns.each do |vuln|
 				vuln.exploited_at = exploited_host.updated_at

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 22
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 3
+    PATCH = 4
+
+    PRERELEASE = 'convert-find-all-by'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.


### PR DESCRIPTION
This PR updates the #find_all_by_X to rails 4 #where syntax.

For example:

Old syntax: `services.find_all_by_host_id(host_id).each do |e|`
New syntax: `services.where(host_id: host_id).each do |e|`

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release
## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1.5@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`