### PR TITLE
Feature/msp 11994/add note id to vuln

### DIFF
--- a/app/models/mdm/note.rb
+++ b/app/models/mdm/note.rb
@@ -23,6 +23,15 @@ class Mdm::Note < ActiveRecord::Base
              class_name: 'Mdm::Service',
              inverse_of: :notes
 
+  # @!attribute [rw] vuln
+  #   The vuln to which this note is attached.
+  #
+  #   @return [Mdm::Vuln] if note is attached to an {Mdm::Vuln}.
+  #   @return [nil] if not is attached to an {Mdm::Host}.
+  belongs_to :vuln,
+             class_name: 'Mdm::Vuln',
+             inverse_of: :notes
+
   # @!attribute [rw] workspace
   #   The workspace in which the {#host} or {#service} exists.
   #

--- a/app/models/mdm/vuln.rb
+++ b/app/models/mdm/vuln.rb
@@ -56,6 +56,16 @@ class Mdm::Vuln < ActiveRecord::Base
            dependent: :destroy,
            inverse_of: :vuln
 
+  # @!attribute [rw] notes
+  #   Notes about the vuln entered by a user with {Mdm::Note#created_at oldest notes} first.
+  #
+  #   @return [Array<Mdm::Note>]
+  has_many :notes,
+           class_name: 'Mdm::Note',
+           inverse_of: :vuln,
+           dependent: :delete_all,
+           order: 'notes.created_at'
+
   #
   # Through :vuln_refs
   #

--- a/db/migrate/20150209195939_add_vuln_id_to_note.rb
+++ b/db/migrate/20150209195939_add_vuln_id_to_note.rb
@@ -1,0 +1,6 @@
+class AddVulnIdToNote < ActiveRecord::Migration
+  def change
+    add_column :notes, :vuln_id, :integer
+    add_index :notes, :vuln_id
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,6 +8,8 @@ module MetasploitDataModels
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 7
 
+
+    PRERELEASE = 'add-note-id-to-vuln'
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,7 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 22
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 7
+    PATCH = 9
 
 
     PRERELEASE = 'add-note-id-to-vuln'

--- a/spec/app/models/mdm/note_spec.rb
+++ b/spec/app/models/mdm/note_spec.rb
@@ -21,6 +21,7 @@ describe Mdm::Note do
       it { should have_db_column(:workspace_id).of_type(:integer).with_options(:null => false, :default =>1) }
       it { should have_db_column(:host_id).of_type(:integer) }
       it { should have_db_column(:service_id).of_type(:integer) }
+      it { should have_db_column(:vuln_id).of_type(:integer) }
       it { should have_db_column(:ntype).of_type(:string) }
       it { should have_db_column(:critical).of_type(:boolean) }
       it { should have_db_column(:seen).of_type(:boolean) }
@@ -44,6 +45,7 @@ describe Mdm::Note do
     it { should belong_to(:workspace).class_name('Mdm::Workspace') }
     it { should belong_to(:host).class_name('Mdm::Host') }
     it { should belong_to(:service).class_name('Mdm::Service') }
+    it { should belong_to(:vuln).class_name('Mdm::Vuln') }
   end
 
   context 'scopes' do

--- a/spec/app/models/mdm/vuln_spec.rb
+++ b/spec/app/models/mdm/vuln_spec.rb
@@ -42,6 +42,7 @@ describe Mdm::Vuln do
     it { should have_many(:vuln_details).class_name('Mdm::VulnDetail').dependent(:destroy) }
     # @todo https://www.pivotaltracker.com/story/show/49004623
     it { should have_many(:vulns_refs).class_name('Mdm::VulnRef').dependent(:destroy) }
+    it { should have_many(:notes).class_name('Mdm::Note').dependent(:delete_all).order('notes.created_at') }
 
     context 'module_details' do
       it { should have_many(:module_details).class_name('Mdm::Module::Detail').through(:module_refs) }

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -818,7 +818,8 @@ CREATE TABLE notes (
     updated_at timestamp without time zone,
     critical boolean,
     seen boolean,
-    data text
+    data text,
+    vuln_id integer
 );
 
 
@@ -2680,6 +2681,13 @@ CREATE INDEX index_notes_on_ntype ON notes USING btree (ntype);
 
 
 --
+-- Name: index_notes_on_vuln_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_notes_on_vuln_id ON notes USING btree (vuln_id);
+
+
+--
 -- Name: index_refs_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2990,6 +2998,8 @@ INSERT INTO schema_migrations (version) VALUES ('20140905031549');
 INSERT INTO schema_migrations (version) VALUES ('20150112203945');
 
 INSERT INTO schema_migrations (version) VALUES ('20150205192745');
+
+INSERT INTO schema_migrations (version) VALUES ('20150209195939');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release
## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1.5@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`