### PR TITLE
Bug/msp 11643/unique services

### DIFF
--- a/app/models/mdm/service.rb
+++ b/app/models/mdm/service.rb
@@ -217,6 +217,14 @@ class Mdm::Service < ActiveRecord::Base
             numericality: {
                 only_integer: true
             }
+  validates :port,
+            uniqueness: {
+              message: 'already exists on this host and protocol',
+              scope: [
+                :host_id,
+                :proto
+              ]
+            }
   validates :proto,
             inclusion: {
                 in: PROTOS

--- a/db/migrate/20150212214222_remove_duplicate_services2.rb
+++ b/db/migrate/20150212214222_remove_duplicate_services2.rb
@@ -1,0 +1,12 @@
+class RemoveDuplicateServices2 < ActiveRecord::Migration
+  def change
+    duplicate_keys = Mdm::Service.count(group: [:host_id, :port, :proto]).select { |k,v| v >1 }.keys
+    duplicate_keys.each do |keys|
+      duplicate_services = Mdm::Service.where(host_id: keys[0], port: keys[1], proto: keys[2]).order(:created_at)
+      duplicate_services.pop
+      duplicate_services.each(&:destroy)
+    end
+
+    add_index :services, [:host_id, :port, :proto], unique: true
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -4,9 +4,11 @@ module MetasploitDataModels
     # The major version number.
     MAJOR = 0
     # The minor version number, scoped to the {MAJOR} version number.
-    MINOR = 22
+    MINOR = 23
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 8
+    PATCH = 0
+
+    PRERELEASE = 'unique-services'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -154,5 +154,13 @@ describe Mdm::Service do
     it { should validate_numericality_of(:port).only_integer }
     it { should ensure_inclusion_of(:proto).in_array(described_class::PROTOS) }
 
+    context 'when a duplicate service already exists' do
+      let(:service1) { FactoryGirl.create(:mdm_service)}
+      let(:service2) { FactoryGirl.build(:mdm_service, :host => service1.host, :port => service1.port, :proto => service1.proto )}
+      it 'is not valid' do
+        expect(service2).to_not be_valid
+      end
+    end
+
   end
 end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -2687,6 +2687,13 @@ CREATE INDEX index_refs_on_name ON refs USING btree (name);
 
 
 --
+-- Name: index_services_on_host_id_and_port_and_proto; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX index_services_on_host_id_and_port_and_proto ON services USING btree (host_id, port, proto);
+
+
+--
 -- Name: index_services_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2990,6 +2997,8 @@ INSERT INTO schema_migrations (version) VALUES ('20140905031549');
 INSERT INTO schema_migrations (version) VALUES ('20150112203945');
 
 INSERT INTO schema_migrations (version) VALUES ('20150205192745');
+
+INSERT INTO schema_migrations (version) VALUES ('20150212214222');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
adds validation that you cannot have more than one service on a host with the same port and protocol

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on DESTINATION

## Version

### Compatible changes

If the change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit_data_models/version.rb).

### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment
[`MINOR`](lib/metasploit_data_models/version.rb) and reset [`PATCH`](lib/metasploit_data_models/version.rb) to `0`.

- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update
[`MINOR`](lib/metasploit_data_models/version.rb) and [`PATCH`](lib/metasploit_data_models/version.rb) and commit the changes.

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-1.9.3@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`