### PR TITLE
Feature/msp 11926/move auto exploitation match

### DIFF
--- a/app/models/metasploit_data_models/automatic_exploitation.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation.rb
@@ -1,0 +1,5 @@
+module MetasploitDataModels::AutomaticExploitation
+  def self.table_name_prefix
+    'automatic_exploitation_'
+  end
+end

--- a/app/models/metasploit_data_models/automatic_exploitation/match.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match.rb
@@ -1,3 +1,21 @@
 class MetasploitDataModels::AutomaticExploitation::Match < ActiveRecord::Base
+  #
+  # Associations
+  #
+
+  # @!attribute matchable
+  #   A (polymorphic) "matchable" entity like a {Mdm::Vuln} or {Mdm::Service}
+  #
+  #   @return [Mdm::Vuln, Mdm::Service]
+  belongs_to :matchable, polymorphic: true
+  attr_accessible :matchable
+
+  # @!attribute module_detail
+  #   The MSF module that this match connects to
+  #
+  #   @return [Mdm::Module::Detail]
+  belongs_to :module_detail, class_name: "Mdm::Module::Detail"
+
+
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit_data_models/automatic_exploitation/match.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match.rb
@@ -1,0 +1,3 @@
+class MetasploitDataModels::AutomaticExploitation::Match < ActiveRecord::Base
+  Metasploit::Concern.run(self)
+end

--- a/app/models/metasploit_data_models/automatic_exploitation/match.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match.rb
@@ -1,4 +1,7 @@
 class MetasploitDataModels::AutomaticExploitation::Match < ActiveRecord::Base
+  attr_accessible :match_set_id, :module_detail_id
+
+
   #
   # Associations
   #

--- a/db/migrate/20131002004641_create_automatic_exploitation_matches.rb
+++ b/db/migrate/20131002004641_create_automatic_exploitation_matches.rb
@@ -1,7 +1,6 @@
 class CreateAutomaticExploitationMatches < ActiveRecord::Migration
   def change
     create_table :automatic_exploitation_matches do |t|
-      t.integer :vuln_id
       t.integer :ref_id
       t.string :state
       t.integer :nexpose_data_vulnerability_definition_id
@@ -10,6 +9,5 @@ class CreateAutomaticExploitationMatches < ActiveRecord::Migration
     end
 
     add_index :automatic_exploitation_matches, :ref_id
-    add_index :automatic_exploitation_matches, :vuln_id
   end
 end

--- a/db/migrate/20131002004641_create_automatic_exploitation_matches.rb
+++ b/db/migrate/20131002004641_create_automatic_exploitation_matches.rb
@@ -1,0 +1,15 @@
+class CreateAutomaticExploitationMatches < ActiveRecord::Migration
+  def change
+    create_table :automatic_exploitation_matches do |t|
+      t.integer :vuln_id
+      t.integer :ref_id
+      t.string :state
+      t.integer :nexpose_data_vulnerability_definition_id
+
+      t.timestamps
+    end
+
+    add_index :automatic_exploitation_matches, :ref_id
+    add_index :automatic_exploitation_matches, :vuln_id
+  end
+end

--- a/db/migrate/20131011184338_module_detail_on_automatic_exploitation_match.rb
+++ b/db/migrate/20131011184338_module_detail_on_automatic_exploitation_match.rb
@@ -1,0 +1,10 @@
+class ModuleDetailOnAutomaticExploitationMatch < ActiveRecord::Migration
+  def up
+    rename_column :automatic_exploitation_matches, :ref_id, :module_detail_id
+    add_column :automatic_exploitation_matches, :match_set_id, :integer
+  end
+
+  def down
+    rename_column :automatic_exploitation_matches, :module_detail_id, :ref_id
+  end
+end

--- a/db/migrate/20131021185657_make_match_polymorphic.rb
+++ b/db/migrate/20131021185657_make_match_polymorphic.rb
@@ -1,0 +1,11 @@
+class MakeMatchPolymorphic < ActiveRecord::Migration
+  def up
+    add_column :automatic_exploitation_matches, :matchable_type, :string
+    add_column :automatic_exploitation_matches, :matchable_id, :integer
+  end
+
+  def down
+    remove_column :automatic_exploitation_matches, :matchable_type
+    remove_column :automatic_exploitation_matches, :matchable_id
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 22
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 8
+    PATCH = 9
+    # The prerelease name. Remove on Master
+    PRERELEASE = 'move-auto-exploitation-match'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -66,7 +66,6 @@ ALTER SEQUENCE api_keys_id_seq OWNED BY api_keys.id;
 
 CREATE TABLE automatic_exploitation_matches (
     id integer NOT NULL,
-    vuln_id integer,
     module_detail_id integer,
     state character varying(255),
     nexpose_data_vulnerability_definition_id integer,
@@ -2603,13 +2602,6 @@ ALTER TABLE ONLY workspaces
 --
 
 CREATE INDEX index_automatic_exploitation_matches_on_ref_id ON automatic_exploitation_matches USING btree (module_detail_id);
-
-
---
--- Name: index_automatic_exploitation_matches_on_vuln_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_automatic_exploitation_matches_on_vuln_id ON automatic_exploitation_matches USING btree (vuln_id);
 
 
 --

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -61,6 +61,43 @@ ALTER SEQUENCE api_keys_id_seq OWNED BY api_keys.id;
 
 
 --
+-- Name: automatic_exploitation_matches; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE automatic_exploitation_matches (
+    id integer NOT NULL,
+    vuln_id integer,
+    module_detail_id integer,
+    state character varying(255),
+    nexpose_data_vulnerability_definition_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    match_set_id integer,
+    matchable_type character varying(255),
+    matchable_id integer
+);
+
+
+--
+-- Name: automatic_exploitation_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE automatic_exploitation_matches_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: automatic_exploitation_matches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE automatic_exploitation_matches_id_seq OWNED BY automatic_exploitation_matches.id;
+
+
+--
 -- Name: clients; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1822,6 +1859,13 @@ ALTER TABLE ONLY api_keys ALTER COLUMN id SET DEFAULT nextval('api_keys_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY automatic_exploitation_matches ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_matches_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY clients ALTER COLUMN id SET DEFAULT nextval('clients_id_seq'::regclass);
 
 
@@ -2160,6 +2204,14 @@ ALTER TABLE ONLY workspaces ALTER COLUMN id SET DEFAULT nextval('workspaces_id_s
 
 ALTER TABLE ONLY api_keys
     ADD CONSTRAINT api_keys_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automatic_exploitation_matches_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY automatic_exploitation_matches
+    ADD CONSTRAINT automatic_exploitation_matches_pkey PRIMARY KEY (id);
 
 
 --
@@ -2544,6 +2596,20 @@ ALTER TABLE ONLY wmap_targets
 
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_automatic_exploitation_matches_on_ref_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_automatic_exploitation_matches_on_ref_id ON automatic_exploitation_matches USING btree (module_detail_id);
+
+
+--
+-- Name: index_automatic_exploitation_matches_on_vuln_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_automatic_exploitation_matches_on_vuln_id ON automatic_exploitation_matches USING btree (vuln_id);
 
 
 --
@@ -2984,6 +3050,12 @@ INSERT INTO schema_migrations (version) VALUES ('20130531144949');
 INSERT INTO schema_migrations (version) VALUES ('20130604145732');
 
 INSERT INTO schema_migrations (version) VALUES ('20130717150737');
+
+INSERT INTO schema_migrations (version) VALUES ('20131002004641');
+
+INSERT INTO schema_migrations (version) VALUES ('20131011184338');
+
+INSERT INTO schema_migrations (version) VALUES ('20131021185657');
 
 INSERT INTO schema_migrations (version) VALUES ('20140905031549');
 


### PR DESCRIPTION
## Verification
( land this if the [corresponding Pro PR](https://github.com/rapid7/pro/pull/1838) passes )

## Post-Merge steps
- [ ] Edit `lib/metasploit_data_models/version.rb` and change PRERELEASE constant to match the staging branch name: `staging/automatic-exploitation-migration`
- [ ] Commit and push on staging branch to get all specs passing