### PR TITLE
Feature/msp 12173 metasploit data models deprecation warnings

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -7,7 +7,7 @@ unless ENV['RM_INFO']
 end
 
 SimpleCov.configure do
-  load_adapter('rails')
+  load_profile('rails')
 
   # ignore this file
 	add_filter '.simplecov'

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,6 +8,8 @@ module MetasploitDataModels
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 0
 
+    PRERELEASE = 'msp-12173-metasploit-data-models-deprecation-warnings'
+
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.
     #

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 0
 
-    PRERELEASE = 'msp-12173-metasploit-data-models-deprecation-warnings'
+    PRERELEASE = 'MSP-12173-metasploit-data-models-deprecation-warnings'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -52,7 +52,6 @@ module Dummy
     # This will create an empty whitelist of attributes available for mass-assignment for all models
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/spec/factories/mdm/module/details.rb
+++ b/spec/factories/mdm/module/details.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :mdm_module_detail, :class => Mdm::Module::Detail do
-    ignore do
+    transient do
       root {
         MetasploitDataModels.root
       }

--- a/spec/factories/mdm/module/details.rb
+++ b/spec/factories/mdm/module/details.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :mdm_module_detail, :class => Mdm::Module::Detail do
-    transient do
+    ignore do
       root {
         MetasploitDataModels.root
       }


### PR DESCRIPTION
### Description
  
This PR eliminates the following warnings for Rails 4

* Fix attr_accessible warning
* Fix #ignore warning

### Verification Steps

Rails 3

* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no spec failures

Rails 4

* [ ] switch to Rails 4 env
* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no attr_accessible warnings

### Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

### Version
* [ ] Edit `lib/metasploit_data_models/version.rb`
* [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

### Gem build
* [ ] gem build *.gemspec
* [ ] VERIFY the gem has no '.pre' version suffix.

### RSpec
* [ ] `rake spec`
* [ ] VERIFY version examples pass without failures

### Commit & Push
* [ ] `git commit -a`
* [ ] `git push origin master`

## Release
### JRuby
* [ ] `rvm use jruby@metasploit-data-models`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`

### MRI Ruby
* [ ] `rvm use ruby-2.1.5@metasploit-data-models`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`
