### PR TITLE
Feature/msp 12173 metasploit data models deprecation warnings

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -7,7 +7,7 @@ unless ENV['RM_INFO']
 end
 
 SimpleCov.configure do
-  load_adapter('rails')
+  load_profile('rails')
 
   # ignore this file
 	add_filter '.simplecov'

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 8
 
-    PRERELEASE = 'rails-4.0'
+    PRERELEASE = 'MSP-12173-metasploit-data-models-deprecation-warnings'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -52,7 +52,7 @@ module Dummy
     # This will create an empty whitelist of attributes available for mass-assignment for all models
     # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
     # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = false
+    # config.active_record.whitelist_attributes = false
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/spec/factories/mdm/module/details.rb
+++ b/spec/factories/mdm/module/details.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :mdm_module_detail, :class => Mdm::Module::Detail do
-    ignore do
+    transient do
       root {
         MetasploitDataModels.root
       }


### PR DESCRIPTION
### Description
  
This PR eliminates the following warnings for Rails 4

* Fix simplecov load_adapter warning
* Fix attr_accessible warning
* Fix FactoryGirl #ignore warning

### Verification Steps

Rails 3

* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no spec failures

Rails 4

* [ ] switch to Rails 4 env
* [ ] `bundle install`
* [ ] `rake spec`
* [ ] verify no simplecove load_adapter warnings

  `method load_adapter is deprecated. use load_profile instead`

* [ ] verify no attr_accessible warnings

  ```
  DEPRECATION WARNING: Model based mass assignment security
  has been extracted out of Rails into a gem. Please use the new
  recommended protection model for params or add `protected_attributes`
  to your Gemfile to use the old one.

  
  To disable this message remove the `whitelist_attributes` option from
  your `config/application.rb` file and any `mass_assignment_sanitizer`
  options from your `config/environments/*.rb` files.

  See http://guides.rubyonrails.org/security.html#mass-assignment for more information.
  ```

* [ ] verify no FactoryGirl #ignore warnings

  ```
  DEPRECATION WARNING: `#ignore` is deprecated and will be removed in 5.0.
  Please use `#transient` instead. (called from block (2 levels) in
  <top (required)> at /Users/sgonzalez/rapid7/metasploit_data_models/spec/
  factories/mdm/module/details.rb:3)
  ```

### Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

### Version
* [ ] Edit `lib/metasploit_data_models/version.rb`
* [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

### Gem build
* [ ] gem build *.gemspec
* [ ] VERIFY the gem has no '.pre' version suffix.

### RSpec
* [ ] `rake spec`
* [ ] VERIFY version examples pass without failures

### Commit & Push
* [ ] `git commit -a`
* [ ] `git push origin master`

## Release
### JRuby
* [ ] `rvm use jruby@metasploit-data-models`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`

### MRI Ruby
* [ ] `rvm use ruby-2.1.5@metasploit-data-models`
* [ ] `rm Gemfile.lock`
* [ ] `bundle install`
* [ ] `rake release`
