### PR TITLE
Feature/msp 12172/create module run

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -66,7 +66,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [rw] clients
   #   Users connected to this host
   #
-  #   @return [Array<Mdm::Client>]
+  #   @return [ActiveRecord::Relation<Mdm::Client>]
   has_many :clients,
            class_name: 'Mdm::Client',
            dependent: :destroy,
@@ -84,7 +84,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [rw] task_hosts
   #   Details about what Tasks touched this host
   #
-  #   @return [Array<Mdm::TaskHost>]
+  #   @return [ActiveRecord::Relation<Mdm::TaskHost>]
   has_many :task_hosts,
            class_name: 'Mdm::TaskHost',
            dependent: :destroy,
@@ -93,7 +93,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [rw] exploit_attempts
   #   Attempts to run exploits against this host.
   #
-  #   @return [Array<Mdm::ExploitAttempt]
+  #   @return [ActiveRecord::Relation<Mdm::ExploitAttempt]
   has_many :exploit_attempts,
            class_name: 'Mdm::ExploitAttempt',
            dependent: :destroy,
@@ -108,7 +108,7 @@ class Mdm::Host < ActiveRecord::Base
            inverse_of: :host
 
   # @!attribute [rw] host_details
-  #   @return [Array<Mdm::HostDetail>]
+  #   @return [ActiveRecord::Relation<Mdm::HostDetail>]
   has_many :host_details,
            class_name: 'Mdm::HostDetail',
            dependent: :destroy,
@@ -138,7 +138,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [rw] notes
   #   Notes about the host entered by a user with {Mdm::Note#created_at oldest notes} first.
   #
-  #   @return [Array<Mdm::Note>]
+  #   @return [ActiveRecord::Relation<Mdm::Note>]
   has_many :notes,
            class_name: 'Mdm::Note',
            inverse_of: :host,
@@ -149,7 +149,7 @@ class Mdm::Host < ActiveRecord::Base
   #   The services running on {Mdm::Service#port ports} on the host with services ordered by {Mdm::Service#port port}
   #   and {Mdm::Service#proto protocol}.
   #
-  #   @return [Array<Mdm::Service>]
+  #   @return [ActiveRecord::Relation<Mdm::Service>]
   has_many :services,
            class_name: 'Mdm::Service',
            dependent: :destroy,
@@ -160,7 +160,7 @@ class Mdm::Host < ActiveRecord::Base
   #   Sessions that are open or previously were open on the host ordered by {Mdm::Session#opened_at when the session was
   #   opened}
   #
-  #   @return [Array<Mdm::Session]
+  #   @return [ActiveRecord::Relation<Mdm::Session]
   has_many :sessions,
            class_name: 'Mdm::Session',
            dependent: :destroy,
@@ -170,7 +170,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [rw] vulns
   #   Vulnerabilities found on the host.
   #
-  #   @return [Array<Mdm::Vuln>]
+  #   @return [ActiveRecord::Relation<Mdm::Vuln>]
   has_many :vulns,
            class_name: 'Mdm::Vuln',
            dependent: :delete_all,
@@ -191,7 +191,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [r] tags
   #   The tags on this host.  Tags are used to filter hosts.
   #
-  #   @return [Array<Mdm::Tag>]
+  #   @return [ActiveRecord::Relation<Mdm::Tag>]
   #   @see #hosts_tags
   has_many :tags, :class_name => 'Mdm::Tag', :through => :hosts_tags
 
@@ -202,14 +202,14 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [r] creds
   #   Credentials captured from {#services}.
   #
-  #   @return [Array<Mdm::Cred>]
+  #   @return [ActiveRecord::Relation<Mdm::Cred>]
   #   @see #services
   has_many :creds, :class_name => 'Mdm::Cred', :through => :services
 
   # @!attribute [r] service_notes
   #   {Mdm::Note Notes} about {#services} running on this host.
   #
-  #   @return [Array<Mdm::Note>]
+  #   @return [ActiveRecord::Relation<Mdm::Note>]
   #   @see #services
   has_many :service_notes,
            class_name: 'Mdm::Note',
@@ -219,9 +219,19 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [r] web_sites
   #   {Mdm::WebSite Web sites} running on top of {#services} on this host.
   #
-  #   @return [Array<Mdm::WebSite>]
+  #   @return [ActiveRecord::Relation<Mdm::WebSite>]
   #   @see services
   has_many :web_sites, :class_name => 'Mdm::WebSite', :through => :services
+
+  # @!attribute [r] module_runs
+  #   Records of Metasploit modules being run on/against this {Mdm::Host}
+  #
+  #   @return [ActiveRecord::Relation<MetasploitDataModels::ModuleRun>]
+  #   @see services
+  has_many :module_runs,
+           class_name: 'MetasploitDataModels::ModuleRun',
+           as: :trackable
+
 
   #
   # through: :task_hosts
@@ -243,7 +253,7 @@ class Mdm::Host < ActiveRecord::Base
   #   Join model between {#vulns} and {#refs}.  Use either of those asssociations instead of this join model.
   #
   #   @todo https://www.pivotaltracker.com/story/show/49004623
-  #   @return [Array<Mdm::VulnRef>]
+  #   @return [ActiveRecord::Relation<Mdm::VulnRef>]
   #   @see #refs
   #   @see #vulns
 	has_many :vuln_refs, :class_name => 'Mdm::VulnRef', :source => :vulns_refs, :through => :vulns
@@ -255,7 +265,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [r] refs
   #   External references, such as CVE, to vulnerabilities found on this host.
   #
-  #   @return [Array<Mdm::Ref>]
+  #   @return [ActiveRecord::Relation<Mdm::Ref>]
   #   @see #vuln_refs
 	has_many :refs, :class_name => 'Mdm::Ref', :through => :vuln_refs
 
@@ -266,7 +276,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [r] module_refs
   #   {Mdm::Module::Ref References for modules} for {Mdm::Ref references for vulnerabilities}.
   #
-  #   @return [Array<Mdm::Module::Ref>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Ref>]
 	has_many :module_refs, :class_name => 'Mdm::Module::Ref', :through => :refs
 
 	#
@@ -276,7 +286,7 @@ class Mdm::Host < ActiveRecord::Base
   # @!attribute [r] module_details
   #   {Mdm::Module::Detail Details about modules} that were used to find {#vulns vulnerabilities} on this host.
   #
-  #   @return [Array<Mdm::Module::Detail]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Detail]
 	has_many :module_details,
            :class_name => 'Mdm::Module::Detail',
            :source =>:detail,

--- a/app/models/mdm/loot.rb
+++ b/app/models/mdm/loot.rb
@@ -32,6 +32,15 @@ class Mdm::Loot < ActiveRecord::Base
              class_name: 'Mdm::Host',
              inverse_of: :loots
 
+  # @!attribute [rw] module_run
+  #   The run of Metasploit content that acquired the loot
+  #
+  #   @return [MetasploitDataModels::ModuleRun]
+  belongs_to :module_run,
+             class_name: 'MetasploitDataModels::ModuleRun',
+             foreign_key: :module_run_id,
+             inverse_of: :loots
+
   # @!attribute [rw] service
   #   The service running on the {#host} from which the loot was gathered.
   #

--- a/app/models/mdm/module/detail.rb
+++ b/app/models/mdm/module/detail.rb
@@ -49,44 +49,51 @@ class Mdm::Module::Detail < ActiveRecord::Base
   # @!attribute [rw] actions
   #   Auxiliary actions to perform when this running this module.
   #
-  #   @return [Array<Mdm::Module::Action>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Action>]
   has_many :actions,   :class_name => 'Mdm::Module::Action',   :dependent => :destroy
 
   # @!attribute [rw] archs
   #   Architectures supported by this module.
   #
-  #   @return [Array<Mdm::Module::Arch>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Arch>]
   has_many :archs,     :class_name => 'Mdm::Module::Arch',     :dependent => :destroy
 
   # @!attribute [rw] authors
   #   Authors (and their emails) of this module.  Usually includes the original discoverer who wrote the
   #   proof-of-concept and then the people that ported the proof-of-concept to metasploit-framework.
   #
-  #   @return [Array<Mdm::Module::Mixin>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Mixin>]
   has_many :authors,   :class_name => 'Mdm::Module::Author',   :dependent => :destroy
 
   # @!attribute [rw] mixins
   #   Mixins used by this module.
   #
-  #   @return [Array<Mdm::Module::Mixin>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Mixin>]
   has_many :mixins,    :class_name => 'Mdm::Module::Mixin',    :dependent => :destroy
+
+  # @!attribute [rw] mixins
+  #   Records of this module content having been attempted as part of Metasploit usage
+  #   @return [ActiveRecord::Relation<MetasploitDataModels::ModuleRun>]
+  has_many :module_runs,
+           class_name: 'MetasploitDataModels::ModuleRun',
+           inverse_of: :module_detail
 
   # @!attribute [rw] platforms
   #   Platforms supported by this module.
   #
-  #   @return [Array<Mdm::Module::Platform>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Platform>]
   has_many :platforms, :class_name => 'Mdm::Module::Platform', :dependent => :destroy
 
   # @!attribute [rw] refs
   #   External references to the vulnerabilities this module exploits.
   #
-  #   @return [Array<Mdm::Module::Ref>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Ref>]
   has_many :refs,      :class_name => 'Mdm::Module::Ref',      :dependent => :destroy
 
   # @!attribute [rw] targets
   #   Names of targets with different configurations that can be exploited by this module.
   #
-  #   @return [Array<Mdm::Module::Target>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Target>]
   has_many :targets,   :class_name => 'Mdm::Module::Target',   :dependent => :destroy
 
   #

--- a/app/models/mdm/module/detail.rb
+++ b/app/models/mdm/module/detail.rb
@@ -71,12 +71,6 @@ class Mdm::Module::Detail < ActiveRecord::Base
   #   @return [ActiveRecord::Relation<Mdm::Module::Mixin>]
   has_many :mixins,    :class_name => 'Mdm::Module::Mixin',    :dependent => :destroy
 
-  # @!attribute [rw] mixins
-  #   Records of this module content having been attempted as part of Metasploit usage
-  #   @return [ActiveRecord::Relation<MetasploitDataModels::ModuleRun>]
-  has_many :module_runs,
-           class_name: 'MetasploitDataModels::ModuleRun',
-           inverse_of: :module_detail
 
   # @!attribute [rw] platforms
   #   Platforms supported by this module.

--- a/app/models/mdm/session.rb
+++ b/app/models/mdm/session.rb
@@ -34,11 +34,28 @@ class Mdm::Session < ActiveRecord::Base
   # @!attribute [rw] routes
   #   Routes tunneled throug this session.
   #
-  #   @return [Array<Mdm::Route>]
+  #   @return [ActiveRecord::Relation<Mdm::Route>]
   has_many :routes,
            class_name: 'Mdm::Route',
            dependent: :delete_all,
            inverse_of: :session
+
+  # @!attribute [rw] originating_module_run
+  #   Records the Metasploit modules run that created this session
+  #
+  #   @return [MetasploitDataModels::ModuleRun]
+  belongs_to :originating_module_run,
+           class_name: 'MetasploitDataModels::ModuleRun',
+           foreign_key: :module_run_id,
+           inverse_of: :spawned_session
+
+  # @!attribute [rw] target_module_runs
+  #   Records the Metasploit modules run on this session
+  #
+  #   @return [ActiveRecord::Relation<MetasploitDataModels::ModuleRun>]
+  has_many :target_module_runs,
+           class_name: 'MetasploitDataModels::ModuleRun',
+           inverse_of: :target_session
 
   # @!attribute vuln_attempt
   #   Vulnerability attempt that created this session.

--- a/app/models/mdm/user.rb
+++ b/app/models/mdm/user.rb
@@ -13,6 +13,7 @@ class Mdm::User < ActiveRecord::Base
   has_many :module_runs,
            class_name: 'MetasploitDataModels::ModuleRun',
            inverse_of: :user
+
   has_many :tags,
            class_name: 'Mdm::Tag',
            inverse_of: :user

--- a/app/models/mdm/user.rb
+++ b/app/models/mdm/user.rb
@@ -10,9 +10,13 @@ class Mdm::User < ActiveRecord::Base
            foreign_key: 'owner_id',
            inverse_of: :owner
 
+  has_many :module_runs,
+           class_name: 'MetasploitDataModels::ModuleRun',
+           inverse_of: :user
   has_many :tags,
            class_name: 'Mdm::Tag',
            inverse_of: :user
+
 
   has_and_belongs_to_many :workspaces, :join_table => 'workspace_members', :uniq => true, :class_name => 'Mdm::Workspace'
 

--- a/app/models/mdm/vuln.rb
+++ b/app/models/mdm/vuln.rb
@@ -32,7 +32,7 @@ class Mdm::Vuln < ActiveRecord::Base
   # @!attribute [rw] vuln_attempts
   #   Attempts to exploit this vulnerability.
   #
-  #   @return [Array<Mdm::VulnAttempt>]
+  #   @return [ActiveRecord::Relation<Mdm::VulnAttempt>]
   has_many :vuln_attempts,
            class_name: 'Mdm::VulnAttempt',
            dependent: :destroy,
@@ -41,7 +41,7 @@ class Mdm::Vuln < ActiveRecord::Base
   # @!attribute [rw] vuln_details
   #   Additional information about this vulnerability.
   #
-  #   @return [Array<Mdm::VulnDetail>]
+  #   @return [ActiveRecord::Relation<Mdm::VulnDetail>]
   has_many :vuln_details,
            class_name: 'Mdm::VulnDetail',
            dependent: :destroy,
@@ -50,7 +50,7 @@ class Mdm::Vuln < ActiveRecord::Base
   # @!attribute [rw] vulns_refs
   #   Join model that joins this vuln to its {Mdm::Ref external references}.
   #
-  #   @return [Array<Mdm::VulnRef>]
+  #   @return [ActiveRecord::Relation<Mdm::VulnRef>]
   has_many :vulns_refs,
            class_name: 'Mdm::VulnRef',
            dependent: :destroy,
@@ -59,7 +59,7 @@ class Mdm::Vuln < ActiveRecord::Base
   # @!attribute [rw] notes
   #   Notes about the vuln entered by a user with {Mdm::Note#created_at oldest notes} first.
   #
-  #   @return [Array<Mdm::Note>]
+  #   @return [<ActiveRecord::RelationMdm::Note>]
   has_many :notes,
            class_name: 'Mdm::Note',
            inverse_of: :vuln,
@@ -73,7 +73,7 @@ class Mdm::Vuln < ActiveRecord::Base
   # @!attribute [r] refs
   #   External references to this vulnerability.
   #
-  #   @return [Array<Mdm::Ref>]
+  #   @return [ActiveRecord::Relation<Mdm::Ref>]
   has_many :refs, :class_name => 'Mdm::Ref', :through => :vulns_refs
 
   #
@@ -83,8 +83,17 @@ class Mdm::Vuln < ActiveRecord::Base
   # @!attribute [r] module_refs
   #   References in module that match {Mdm::Ref#name names} in {#refs}.
   #
-  #   @return [Array<Mdm::Module::Ref>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Ref>]
   has_many :module_refs, :class_name => 'Mdm::Module::Ref', :through => :refs
+
+
+  # @!attribute [r] module_runs
+  #   References to times that a module has been run to exercise this vuln
+  #
+  #   @return [ActiveRecord::Relation<MetasploitDataModels::ModuleRun>]
+  has_many :module_runs,
+           class_name: 'MetasploitDataModels::ModuleRun',
+           as: :trackable
 
   #
   # Through module_refs
@@ -93,7 +102,7 @@ class Mdm::Vuln < ActiveRecord::Base
   # @!attribute [r] module_details
   #   {Mdm::Module::Detail Modules} that share the same external references as this vuln.
   #
-  #   @return [Array<Mdm::Module::Detail>]
+  #   @return [ActiveRecord::Relation<Mdm::Module::Detail>]
   has_many :module_details,
            :class_name => 'Mdm::Module::Detail',
            :source => :detail,

--- a/app/models/metasploit_data_models/module_run.rb
+++ b/app/models/metasploit_data_models/module_run.rb
@@ -8,7 +8,7 @@ class MetasploitDataModels::ModuleRun < ActiveRecord::Base
   #
 
   # Marks the module as having successfully run
-  SUCCEED      = 'succeeded'
+  SUCCEED     = 'succeeded'
   # Marks the run as having not run successfully
   FAIL        = 'failed'
   # Marks the module as having had a runtime error
@@ -64,14 +64,6 @@ class MetasploitDataModels::ModuleRun < ActiveRecord::Base
   # Associations
   #
 
-
-  # @!attribute [rw] module_detail
-  #  A reference to the Metasploit content module in the DB cache
-  #
-  #  @return [Mdm::Module::Detail]
-  belongs_to :module_detail,
-             class_name: 'Mdm::Module::Detail',
-             inverse_of: :module_runs
 
 
   # @!attribute [rw] loots
@@ -151,7 +143,7 @@ class MetasploitDataModels::ModuleRun < ActiveRecord::Base
   # Mark the object as invalid if there is no associated #module_name or {Mdm::ModuleDetail}
   # @return [void]
   def module_information_is_present
-    if module_name.blank? && module_detail.blank?
+    if module_full_name.blank?
       errors.add(:base, "One of module_name or module_detail_id must be set")
     end
   end
@@ -161,15 +153,8 @@ class MetasploitDataModels::ModuleRun < ActiveRecord::Base
   def no_spawned_session_for_non_exploits
     return true unless spawned_session.present? # nothing to do unless spawned_session is set
 
-    if module_name.present?
-      if module_name.split('/').first != 'exploit'
-        errors.add(:base, 'spawned_session cannot be set for non-exploit modules. Use target_session.')
-      end
-
-    elsif module_detail.present?
-      if module_detail.mtype != 'exploit'
-        errors.add(:base, 'spawned_session cannot be set for non-exploit modules. Use target_session.')
-      end
+    if module_full_name.split('/').first != 'exploit'
+      errors.add(:base, 'spawned_session cannot be set for non-exploit modules. Use target_session.')
     end
   end
 
@@ -178,15 +163,8 @@ class MetasploitDataModels::ModuleRun < ActiveRecord::Base
   def no_target_session_for_exploits
     return true unless target_session.present? # nothing to do unless target_session is set
 
-    if module_name.present?
-      if module_name.split('/').first == 'exploit'
-        errors.add(:base, 'target_session cannot be set for exploit modules. Use spawned_session.')
-      end
-
-    elsif module_detail.present?
-      if module_detail.mtype == 'exploit'
-        errors.add(:base, 'target_session cannot be set for exploit modules. Use spawned_session.')
-      end
+    if module_full_name.split('/').first == 'exploit'
+      errors.add(:base, 'target_session cannot be set for exploit modules. Use spawned_session.')
     end
   end
 

--- a/app/models/metasploit_data_models/module_run.rb
+++ b/app/models/metasploit_data_models/module_run.rb
@@ -1,0 +1,78 @@
+# Holds the record of having launched piece of Metasploit content.
+# Has associations to {Mdm::User} for audit purposes, and makes polymorphic associations to things like
+# {Mdm::Vuln} and {Mdm::Host} for flexible record keeping about activity attacking either specific vulns or just
+# making mischief on specific remote targets w/out the context of a vuln or even a remote IP service.
+class MetasploitDataModels::ModuleRun < ActiveRecord::Base
+  #
+  # Constants
+  #
+
+  # Marks the module as having successfully run
+  STATUS_EXPLOITED     = 'exploited'
+  # Marks the run as having not run successfully
+  STATUS_FAILED        = 'failed'
+  # Marks the module as having had a runtime error
+  STATUS_ERROR         = 'error'
+  # {ModuleRun} objects will be validated against these statuses
+  VALID_STATUSES = [STATUS_EXPLOITED, STATUS_FAILED, STATUS_ERROR]
+
+
+  #
+  # Attributes
+  #
+
+  # @!attribute [rw] attempted_at
+  #   The date/time when this module was run
+  # @return [Datetime]
+
+  # @!attribute [rw] fail_detail
+  #   Arbitrary information captured by the module to give in-depth reason for failure
+  # @return [String]
+
+  # @!attribute [rw] fail_reason
+  #   One of the values of the constants in {Msf::Module::Failure}
+  # @return [String]
+
+  # @!attribute [rw] module_name
+  #   The Msf::Module#fullname of the module being run
+  # @return [String]
+
+  # @!attribute [rw] port
+  #   The port that the remote host was attacked on, if any
+  # @return [Fixnum]
+
+  # @!attribute [rw] proto
+  #   The name of the protocol that the host was attacked on, if any
+  # @return [String]
+
+  # @!attribute [rw] session_id
+  #   The {Mdm::Session} that this was run with, in the case of a post module. In exploit modules, this field will
+  #   remain null.
+  # @return [Datetime]
+
+  # @!attribute [rw] status
+  #   The result of running the module
+  # @return [String]
+
+  # @!attribute [rw] username
+  #   The name of the user running this module
+  # @return [Datetime]
+
+
+
+  #
+  # Associations
+  #
+
+
+  belongs_to :trackable, polymorphic: true
+
+  # The user that launched this module
+  # @return [Mdm::User]
+  belongs_to :user,
+             class_name:  "Mdm::User",
+             foreign_key: "user_id",
+             inverse_of: :module_runs
+
+
+end

--- a/app/models/metasploit_data_models/module_run.rb
+++ b/app/models/metasploit_data_models/module_run.rb
@@ -65,16 +65,49 @@ class MetasploitDataModels::ModuleRun < ActiveRecord::Base
   #
 
 
-  # A reference to the Metasploit content module in the DB cache
-  # @return [Mdm::Module::Detail]
+  # @!attribute [rw] module_detail
+  #  A reference to the Metasploit content module in the DB cache
+  #
+  #  @return [Mdm::Module::Detail]
   belongs_to :module_detail,
              class_name: 'Mdm::Module::Detail',
              inverse_of: :module_runs
 
+
+  # @!attribute [rw] spawned_session
+  #
+  #  The session created by running this module.
+  #  Note that this is NOT the session that modules are run on.
+  #
+  #  @return [Mdm::Session]
+  has_one :spawned_session,
+             class_name: 'Mdm::Session',
+             inverse_of: :originating_module_run
+
+
+  # @!attribute [rw] target_session
+  #
+  #  The session this module was run on, if any.
+  #  Note that this is NOT a session created by this module run
+  #  of exploit modules.
+  #
+  #  @return [Mdm::Session]
+  belongs_to :target_session,
+             class_name: 'Mdm::Session',
+             foreign_key: :session_id,
+             inverse_of: :target_module_runs
+
+
+
+  # Declares this model to implement a polymorphic relationship with other models.
   belongs_to :trackable, polymorphic: true
 
-  # The user that launched this module
-  # @return [Mdm::User]
+
+  # @!attribute [rw] user
+  #
+  #  The user that launched this module
+  #
+  #  @return [Mdm::User]
   belongs_to :user,
              class_name:  'Mdm::User',
              foreign_key: 'user_id',

--- a/app/models/metasploit_data_models/module_run.rb
+++ b/app/models/metasploit_data_models/module_run.rb
@@ -1,7 +1,11 @@
-# {MetasploitDataModels::ModuleRun} holds the record of having launched piece of Metasploit content.
+# {MetasploitDataModels::ModuleRun} holds the record of having launched a piece of Metasploit content.
 # It has associations to {Mdm::User} for audit purposes, and makes polymorphic associations to things like
 # {Mdm::Vuln} and {Mdm::Host} for flexible record keeping about activity attacking either specific vulns or just
 # making mischief on specific remote targets w/out the context of a vuln or even a remote IP service.
+#
+# There are also associations to {Mdm::Session} for two use cases: a `spawned_session` is a
+# session created by the ModuleRun. A `target_session` is a session that the ModuleRun
+# is acting upon (e.g.) for running a post module.
 class MetasploitDataModels::ModuleRun < ActiveRecord::Base
   #
   # Constants
@@ -23,40 +27,40 @@ class MetasploitDataModels::ModuleRun < ActiveRecord::Base
 
   # @!attribute [rw] attempted_at
   #   The date/time when this module was run
-  # @return [Datetime]
+  #   @return [Datetime]
 
   # @!attribute [rw] fail_detail
   #   Arbitrary information captured by the module to give in-depth reason for failure
-  # @return [String]
+  #   @return [String]
 
   # @!attribute [rw] fail_reason
   #   One of the values of the constants in {Msf::Module::Failure}
-  # @return [String]
+  #   @return [String]
 
   # @!attribute [rw] module_name
   #   The Msf::Module#fullname of the module being run
-  # @return [String]
+  #   @return [String]
 
   # @!attribute [rw] port
   #   The port that the remote host was attacked on, if any
-  # @return [Fixnum]
+  #   @return [Fixnum]
 
   # @!attribute [rw] proto
   #   The name of the protocol that the host was attacked on, if any
-  # @return [String]
+  #   @return [String]
 
   # @!attribute [rw] session_id
   #   The {Mdm::Session} that this was run with, in the case of a post module. In exploit modules, this field will
   #   remain null.
-  # @return [Datetime]
+  #   @return [Datetime]
 
   # @!attribute [rw] status
   #   The result of running the module
-  # @return [String]
+  #   @return [String]
 
   # @!attribute [rw] username
   #   The name of the user running this module
-  # @return [String]
+  #   @return [String]
 
 
 

--- a/db/migrate/20150219173821_create_module_runs.rb
+++ b/db/migrate/20150219173821_create_module_runs.rb
@@ -1,0 +1,21 @@
+class CreateModuleRuns < ActiveRecord::Migration
+  def change
+    create_table :module_runs do |t|
+      t.string :trackable_type
+      t.integer :trackable_id
+      t.datetime :attempted_at
+      t.integer :session_id
+      t.integer :port
+      t.string :proto
+      t.text :fail_detail
+      t.string :status
+      t.string :username
+      t.integer :user_id
+      t.string :fail_reason
+      t.text :module_name
+      t.integer :module_detail_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150219173821_create_module_runs.rb
+++ b/db/migrate/20150219173821_create_module_runs.rb
@@ -1,19 +1,19 @@
 class CreateModuleRuns < ActiveRecord::Migration
   def change
     create_table :module_runs do |t|
-      t.string :trackable_type
-      t.integer :trackable_id
       t.datetime :attempted_at
-      t.integer :session_id
+      t.text :fail_detail
+      t.string :fail_reason
+      t.integer :module_detail_id
+      t.text :module_name
       t.integer :port
       t.string :proto
-      t.text :fail_detail
+      t.integer :session_id
       t.string :status
-      t.string :username
+      t.integer :trackable_id
+      t.string :trackable_type
       t.integer :user_id
-      t.string :fail_reason
-      t.text :module_name
-      t.integer :module_detail_id
+      t.string :username
 
       t.timestamps
     end

--- a/db/migrate/20150219173821_create_module_runs.rb
+++ b/db/migrate/20150219173821_create_module_runs.rb
@@ -5,7 +5,7 @@ class CreateModuleRuns < ActiveRecord::Migration
       t.text :fail_detail
       t.string :fail_reason
       t.integer :module_detail_id
-      t.text :module_name
+      t.text :module_full_name
       t.integer :port
       t.string :proto
       t.integer :session_id

--- a/db/migrate/20150219215039_add_module_run_to_session.rb
+++ b/db/migrate/20150219215039_add_module_run_to_session.rb
@@ -1,0 +1,8 @@
+class AddModuleRunToSession < ActiveRecord::Migration
+  def change
+    change_table :sessions do |t|
+      t.integer :module_run_id
+    end
+    add_index :sessions, :module_run_id
+  end
+end

--- a/db/migrate/20150226151459_add_module_run_fk_to_loot.rb
+++ b/db/migrate/20150226151459_add_module_run_fk_to_loot.rb
@@ -1,0 +1,8 @@
+class AddModuleRunFkToLoot < ActiveRecord::Migration
+  def change
+    change_table(:loots) do |t|
+      t.integer :module_run_id
+      t.index :module_run_id
+    end
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,7 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 23
     # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 1
+    PATCH = 2
+
+    PRERELEASE = 'create-module-run'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/mdm/host_spec.rb
+++ b/spec/app/models/mdm/host_spec.rb
@@ -110,6 +110,7 @@ describe Mdm::Host do
     it { should have_many(:host_details).class_name('Mdm::HostDetail').dependent(:destroy) }
     it { should have_many(:hosts_tags).class_name('Mdm::HostTag') }
     it { should have_many(:loots).class_name('Mdm::Loot').dependent(:destroy).order('loots.created_at DESC') }
+    it { should have_many(:module_runs).class_name('MetasploitDataModels::ModuleRun') }
     it { should have_many(:task_hosts).class_name('Mdm::TaskHost').dependent(:destroy) }
     it { should have_many(:tasks).class_name('Mdm::Task').through(:task_hosts) }
 

--- a/spec/app/models/mdm/loot_spec.rb
+++ b/spec/app/models/mdm/loot_spec.rb
@@ -7,6 +7,7 @@ describe Mdm::Loot do
     it { should belong_to(:workspace).class_name('Mdm::Workspace') }
     it { should belong_to(:service).class_name('Mdm::Service') }
     it { should belong_to(:host).class_name('Mdm::Host') }
+    it { should belong_to(:module_run).class_name('MetasploitDataModels::ModuleRun') }
   end
 
   context 'database' do

--- a/spec/app/models/mdm/session_spec.rb
+++ b/spec/app/models/mdm/session_spec.rb
@@ -25,31 +25,34 @@ describe Mdm::Session do
   context 'database' do
 
     context 'timestamps'do
-      it { should have_db_column(:opened_at).of_type(:datetime).with_options(:null => false) }
-      it { should have_db_column(:closed_at).of_type(:datetime) }
-      it { should have_db_column(:last_seen).of_type(:datetime) }
+      it { is_expected.to have_db_column(:closed_at).of_type(:datetime) }
+      it { is_expected.to have_db_column(:last_seen).of_type(:datetime) }
+      it { is_expected.to have_db_column(:opened_at).of_type(:datetime).with_options(:null => false) }
     end
 
     context 'columns' do
-      it { should have_db_column(:host_id).of_type(:integer) }
-      it { should have_db_column(:stype).of_type(:string) }
-      it { should have_db_column(:via_exploit).of_type(:string) }
-      it { should have_db_column(:via_payload).of_type(:string) }
-      it { should have_db_column(:desc).of_type(:string) }
-      it { should have_db_column(:port).of_type(:integer) }
-      it { should have_db_column(:platform).of_type(:string) }
-      it { should have_db_column(:datastore).of_type(:text) }
-      it { should have_db_column(:local_id).of_type(:integer) }
+      it { is_expected.to have_db_column(:datastore).of_type(:text) }
+      it { is_expected.to have_db_column(:desc).of_type(:string) }
+      it { is_expected.to have_db_column(:host_id).of_type(:integer) }
+      it { is_expected.to have_db_column(:local_id).of_type(:integer) }
+      it { is_expected.to have_db_column(:module_run_id).of_type(:integer) }
+      it { is_expected.to have_db_column(:platform).of_type(:string) }
+      it { is_expected.to have_db_column(:port).of_type(:integer) }
+      it { is_expected.to have_db_column(:stype).of_type(:string) }
+      it { is_expected.to have_db_column(:via_exploit).of_type(:string) }
+      it { is_expected.to have_db_column(:via_payload).of_type(:string) }
     end
   end
 
   context 'associations' do
-    it { should belong_to(:host).class_name('Mdm::Host') }
-    it { should have_many(:events).class_name('Mdm::SessionEvent').dependent(:delete_all) }
-    it { should have_many(:routes).class_name('Mdm::Route').dependent(:delete_all) }
-    it { should have_one(:workspace).class_name('Mdm::Workspace').through(:host) }
-    it { should have_many(:task_sessions).class_name('Mdm::TaskSession').dependent(:destroy)}
-    it { should have_many(:tasks).class_name('Mdm::Task').through(:task_sessions)}
+    it { is_expected.to have_many(:events).class_name('Mdm::SessionEvent').dependent(:delete_all) }
+    it { is_expected.to belong_to(:host).class_name('Mdm::Host') }
+    it { is_expected.to belong_to(:originating_module_run).class_name('MetasploitDataModels::ModuleRun') }
+    it { is_expected.to have_many(:routes).class_name('Mdm::Route').dependent(:delete_all) }
+    it { is_expected.to have_many(:target_module_runs).class_name('MetasploitDataModels::ModuleRun') }
+    it { is_expected.to have_many(:tasks).class_name('Mdm::Task').through(:task_sessions)}
+    it { is_expected.to have_many(:task_sessions).class_name('Mdm::TaskSession').dependent(:destroy) }
+    it { is_expected.to have_one(:workspace).class_name('Mdm::Workspace').through(:host) }
   end
 
   context 'scopes' do

--- a/spec/app/models/mdm/vuln_spec.rb
+++ b/spec/app/models/mdm/vuln_spec.rb
@@ -33,16 +33,15 @@ describe Mdm::Vuln do
 
 
   context 'associations' do
-    it { should belong_to(:host).class_name('Mdm::Host') }
-    it { should belong_to(:service).class_name('Mdm::Service') }
-    it { should have_many(:module_refs).class_name('Mdm::Module::Ref').through(:refs) }
-    # @todo https://www.pivotaltracker.com/story/show/49004623
-    it { should have_many(:refs).class_name('Mdm::Ref').through(:vulns_refs) }
-    it { should have_many(:vuln_attempts).class_name('Mdm::VulnAttempt').dependent(:destroy) }
-    it { should have_many(:vuln_details).class_name('Mdm::VulnDetail').dependent(:destroy) }
-    # @todo https://www.pivotaltracker.com/story/show/49004623
-    it { should have_many(:vulns_refs).class_name('Mdm::VulnRef').dependent(:destroy) }
-    it { should have_many(:notes).class_name('Mdm::Note').dependent(:delete_all).order('notes.created_at') }
+    it { is_expected.to belong_to(:host).class_name('Mdm::Host') }
+    it { is_expected.to belong_to(:service).class_name('Mdm::Service') }
+    it { is_expected.to have_many(:module_refs).class_name('Mdm::Module::Ref').through(:refs) }
+    it { is_expected.to have_many(:module_runs).class_name('MetasploitDataModels::ModuleRun') }
+    it { is_expected.to have_many(:refs).class_name('Mdm::Ref').through(:vulns_refs) }
+    it { is_expected.to have_many(:vuln_attempts).class_name('Mdm::VulnAttempt').dependent(:destroy) }
+    it { is_expected.to have_many(:vuln_details).class_name('Mdm::VulnDetail').dependent(:destroy) }
+    it { is_expected.to have_many(:vulns_refs).class_name('Mdm::VulnRef').dependent(:destroy) }
+    it { is_expected.to have_many(:notes).class_name('Mdm::Note').dependent(:delete_all).order('notes.created_at') }
 
     context 'module_details' do
       it { should have_many(:module_details).class_name('Mdm::Module::Detail').through(:module_refs) }

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -22,10 +22,34 @@ describe MetasploitDataModels::ModuleRun do
 
   context "associations" do
     it { is_expected.to belong_to(:user).class_name('Mdm::User') }
+    it { is_expected.to belong_to(:target_session).class_name('Mdm::Session') }
     it { is_expected.to belong_to(:trackable) }
+    it { is_expected.to have_one(:spawned_session).class_name('Mdm::Session') }
   end
 
   context "validations" do
+    describe "when a session is set on the module run" do
+      before(:each) do
+        module_run.target_session = FactoryGirl.build(:mdm_session)
+      end
+
+      context "when module_name is present" do
+        context "when the module is an exploit" do
+          before(:each){ module_run.module_name = 'exploit/windows/mah-crazy-exploit' }
+
+          it { is_expected.to_not be_valid }
+        end
+      end
+
+      context "when module_detail is present" do
+        before(:each) do
+          module_run.module_detail = FactoryGirl.create(:mdm_module_detail, fullname: 'exploit/windows/some-evil')
+        end
+
+        it { is_expected.to_not be_valid }
+      end
+    end
+
     describe "attempted_at" do
       before(:each){ module_run.attempted_at = nil }
 

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -2,7 +2,63 @@ require 'spec_helper'
 
 describe MetasploitDataModels::ModuleRun do
 
+  subject(:module_run){FactoryGirl.build(:module_run)}
+
   context "associations" do
     it { is_expected.to belong_to(:user).class_name('Mdm::User') }
+    it { is_expected.to belong_to(:trackable) }
+  end
+
+  context "validations" do
+    describe "attempted_at" do
+      before(:each){ module_run.attempted_at = nil }
+
+      it { is_expected.to_not be_valid } 
+    end
+
+    describe "content information" do
+      context "when there is no module_name and no module_detail" do
+        before(:each) do
+          module_run.module_name   = nil
+          module_run.module_detail = nil
+        end
+
+        it { is_expected.to_not be_valid }
+      end
+    end
+
+
+    describe "status" do
+      describe "invalidity" do
+        before(:each) do
+          module_run.status = "invalid nonsense"
+        end
+
+        it { expect(module_run).to_not be_valid}
+      end
+
+      describe "validity" do
+        context "when the module run succeeded" do
+          before(:each){ module_run.status = MetasploitDataModels::ModuleRun::SUCCEED}
+
+          it{ expect(module_run).to be_valid }
+        end
+
+        context "when the module run went normally but failed" do
+          before(:each){ module_run.status = MetasploitDataModels::ModuleRun::FAIL}
+
+          it{ expect(module_run).to be_valid }
+        end
+
+        context "when the module run errored out" do
+          before(:each){ module_run.status = MetasploitDataModels::ModuleRun::ERROR}
+
+          it{ expect(module_run).to be_valid }
+        end
+
+      end
+
+    end
   end
 end
+

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -30,24 +30,51 @@ describe MetasploitDataModels::ModuleRun do
 
   context "validations" do
     describe "when a target_session is set on the module run" do
+      before(:each) do
+        module_run.target_session = FactoryGirl.build(:mdm_session)
+      end
+
       context "when the module is an exploit" do
-        before(:each) do
-          module_run.target_session = FactoryGirl.build(:mdm_session)
-          module_run.module_full_name = 'exploit/windows/mah-crazy-exploit'
+        context "and that exploit IS NOT local" do
+          before(:each) do
+            module_run.module_full_name = 'exploit/windows/mah-crazy-exploit'
+          end
+
+          it { is_expected.to_not be_valid }
         end
 
-        it { is_expected.to_not be_valid }
+        context "and that exploit IS local" do
+          before(:each) do
+            module_run.module_full_name = 'exploit/windows/local/mah-crazy-exploit'
+          end
+
+          it { is_expected.to be_valid }
+        end
       end
     end
 
     describe "when a spawned_session is set on the module run" do
       before(:each) do
         module_run.spawned_session  = FactoryGirl.build(:mdm_session)
-        module_run.module_full_name = 'post/multi/gather/steal-minecraft-maps'
       end
 
       context "when the module is not an exploit" do
-        it { is_expected.to_not be_valid }
+
+        context "and it IS NOT a login scanner" do
+          before(:each) do
+            module_run.module_full_name = 'post/multi/gather/steal-minecraft-maps'
+          end
+
+          it { is_expected.to_not be_valid }
+        end
+
+        context "and it IS a login scanner" do
+          before(:each) do
+            module_run.module_full_name = 'auxiliary/scanner/ssh/ssh_login'
+          end
+
+          it { is_expected.to be_valid }
+        end
       end
     end
 

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -4,6 +4,22 @@ describe MetasploitDataModels::ModuleRun do
 
   subject(:module_run){FactoryGirl.build(:module_run)}
 
+  context "database columns" do
+    it { is_expected.to have_db_column(:attempted_at).of_type(:datetime) }
+    it { is_expected.to have_db_column(:fail_detail).of_type(:text) }
+    it { is_expected.to have_db_column(:fail_reason).of_type(:string) }
+    it { is_expected.to have_db_column(:module_detail_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:module_name).of_type(:text) }
+    it { is_expected.to have_db_column(:port).of_type(:integer) }
+    it { is_expected.to have_db_column(:proto).of_type(:string) }
+    it { is_expected.to have_db_column(:session_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:status).of_type(:string) }
+    it { is_expected.to have_db_column(:trackable_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:trackable_type).of_type(:string) }
+    it { is_expected.to have_db_column(:user_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:username).of_type(:string) }
+  end
+
   context "associations" do
     it { is_expected.to belong_to(:user).class_name('Mdm::User') }
     it { is_expected.to belong_to(:trackable) }

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -24,29 +24,68 @@ describe MetasploitDataModels::ModuleRun do
     it { is_expected.to belong_to(:user).class_name('Mdm::User') }
     it { is_expected.to belong_to(:target_session).class_name('Mdm::Session') }
     it { is_expected.to belong_to(:trackable) }
+    it { is_expected.to have_many(:loots).class_name('Mdm::Loot') }
     it { is_expected.to have_one(:spawned_session).class_name('Mdm::Session') }
   end
 
   context "validations" do
-    describe "when a session is set on the module run" do
+    describe "when a target_session is set on the module run" do
       before(:each) do
         module_run.target_session = FactoryGirl.build(:mdm_session)
       end
 
       context "when module_name is present" do
         context "when the module is an exploit" do
-          before(:each){ module_run.module_name = 'exploit/windows/mah-crazy-exploit' }
+          before(:each) do
+            module_run.module_detail = nil
+            module_run.module_name   = 'exploit/windows/mah-crazy-exploit'
+          end
 
           it { is_expected.to_not be_valid }
         end
       end
 
       context "when module_detail is present" do
+        context "when the module is an exploit" do
+          before(:each) do
+            module_run.module_name   = nil
+            module_run.module_detail = FactoryGirl.create(:mdm_module_detail,
+                                                          fullname: 'exploit/windows/some-evil',
+                                                          mtype: 'exploit')
+          end
+
+          it { is_expected.to_not be_valid }
+        end
+      end
+    end
+
+    describe "when a spawned_session is set on the module run" do
+      before(:each) do
+        module_run.spawned_session = FactoryGirl.build(:mdm_session)
+      end
+
+      context "when the module_name is present" do
         before(:each) do
-          module_run.module_detail = FactoryGirl.create(:mdm_module_detail, fullname: 'exploit/windows/some-evil')
+          module_run.module_name   = 'post/multi/gather/steal-minecraft-maps'
+          module_run.module_detail = nil
         end
 
-        it { is_expected.to_not be_valid }
+        context "when the module is not an exploit" do
+          it { is_expected.to_not be_valid }
+        end
+      end
+
+      context "when the module_detail is present" do
+        before(:each) do
+          module_run.module_name   = nil
+          module_run.module_detail = FactoryGirl.create(:mdm_module_detail,
+                                                        fullname: 'post/multi/gather/steal-minecraft-maps',
+                                                        mtype: 'post')
+        end
+
+        context "when the module is not an exploit" do
+          it { is_expected.to_not be_valid }
+        end
       end
     end
 

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe MetasploitDataModels::ModuleRun do
 
-  subject(:module_run){FactoryGirl.build(:module_run)}
+  subject(:module_run){FactoryGirl.build(:metasploit_data_models_module_run)}
 
   context "database columns" do
     it { is_expected.to have_db_column(:attempted_at).of_type(:datetime) }

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe MetasploitDataModels::ModuleRun do
+
+  context "associations" do
+    it { is_expected.to belong_to(:user).class_name('Mdm::User') }
+  end
+end

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -9,7 +9,7 @@ describe MetasploitDataModels::ModuleRun do
     it { is_expected.to have_db_column(:fail_detail).of_type(:text) }
     it { is_expected.to have_db_column(:fail_reason).of_type(:string) }
     it { is_expected.to have_db_column(:module_detail_id).of_type(:integer) }
-    it { is_expected.to have_db_column(:module_name).of_type(:text) }
+    it { is_expected.to have_db_column(:module_full_name).of_type(:text) }
     it { is_expected.to have_db_column(:port).of_type(:integer) }
     it { is_expected.to have_db_column(:proto).of_type(:string) }
     it { is_expected.to have_db_column(:session_id).of_type(:integer) }
@@ -30,62 +30,24 @@ describe MetasploitDataModels::ModuleRun do
 
   context "validations" do
     describe "when a target_session is set on the module run" do
-      before(:each) do
-        module_run.target_session = FactoryGirl.build(:mdm_session)
-      end
-
-      context "when module_name is present" do
-        context "when the module is an exploit" do
-          before(:each) do
-            module_run.module_detail = nil
-            module_run.module_name   = 'exploit/windows/mah-crazy-exploit'
-          end
-
-          it { is_expected.to_not be_valid }
+      context "when the module is an exploit" do
+        before(:each) do
+          module_run.target_session = FactoryGirl.build(:mdm_session)
+          module_run.module_full_name = 'exploit/windows/mah-crazy-exploit'
         end
-      end
 
-      context "when module_detail is present" do
-        context "when the module is an exploit" do
-          before(:each) do
-            module_run.module_name   = nil
-            module_run.module_detail = FactoryGirl.create(:mdm_module_detail,
-                                                          fullname: 'exploit/windows/some-evil',
-                                                          mtype: 'exploit')
-          end
-
-          it { is_expected.to_not be_valid }
-        end
+        it { is_expected.to_not be_valid }
       end
     end
 
     describe "when a spawned_session is set on the module run" do
       before(:each) do
-        module_run.spawned_session = FactoryGirl.build(:mdm_session)
+        module_run.spawned_session  = FactoryGirl.build(:mdm_session)
+        module_run.module_full_name = 'post/multi/gather/steal-minecraft-maps'
       end
 
-      context "when the module_name is present" do
-        before(:each) do
-          module_run.module_name   = 'post/multi/gather/steal-minecraft-maps'
-          module_run.module_detail = nil
-        end
-
-        context "when the module is not an exploit" do
-          it { is_expected.to_not be_valid }
-        end
-      end
-
-      context "when the module_detail is present" do
-        before(:each) do
-          module_run.module_name   = nil
-          module_run.module_detail = FactoryGirl.create(:mdm_module_detail,
-                                                        fullname: 'post/multi/gather/steal-minecraft-maps',
-                                                        mtype: 'post')
-        end
-
-        context "when the module is not an exploit" do
-          it { is_expected.to_not be_valid }
-        end
+      context "when the module is not an exploit" do
+        it { is_expected.to_not be_valid }
       end
     end
 
@@ -96,10 +58,9 @@ describe MetasploitDataModels::ModuleRun do
     end
 
     describe "content information" do
-      context "when there is no module_name and no module_detail" do
+      context "when there is no module_name" do
         before(:each) do
-          module_run.module_name   = nil
-          module_run.module_detail = nil
+          module_run.module_full_name = nil
         end
 
         it { is_expected.to_not be_valid }

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -61,6 +61,42 @@ ALTER SEQUENCE api_keys_id_seq OWNED BY api_keys.id;
 
 
 --
+-- Name: automatic_exploitation_matches; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE automatic_exploitation_matches (
+    id integer NOT NULL,
+    module_detail_id integer,
+    state character varying(255),
+    nexpose_data_vulnerability_definition_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    match_set_id integer,
+    matchable_type character varying(255),
+    matchable_id integer
+);
+
+
+--
+-- Name: automatic_exploitation_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE automatic_exploitation_matches_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: automatic_exploitation_matches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE automatic_exploitation_matches_id_seq OWNED BY automatic_exploitation_matches.id;
+
+
+--
 -- Name: clients; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -730,6 +766,49 @@ CREATE SEQUENCE module_refs_id_seq
 --
 
 ALTER SEQUENCE module_refs_id_seq OWNED BY module_refs.id;
+
+
+--
+-- Name: module_runs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE module_runs (
+    id integer NOT NULL,
+    trackable_type character varying(255),
+    trackable_id integer,
+    attempted_at timestamp without time zone,
+    session_id integer,
+    port integer,
+    proto character varying(255),
+    fail_detail text,
+    status character varying(255),
+    username character varying(255),
+    user_id integer,
+    fail_reason character varying(255),
+    module_name text,
+    module_detail_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: module_runs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE module_runs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: module_runs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE module_runs_id_seq OWNED BY module_runs.id;
 
 
 --
@@ -1823,6 +1902,13 @@ ALTER TABLE ONLY api_keys ALTER COLUMN id SET DEFAULT nextval('api_keys_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY automatic_exploitation_matches ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_matches_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY clients ALTER COLUMN id SET DEFAULT nextval('clients_id_seq'::regclass);
 
 
@@ -1950,6 +2036,13 @@ ALTER TABLE ONLY module_platforms ALTER COLUMN id SET DEFAULT nextval('module_pl
 --
 
 ALTER TABLE ONLY module_refs ALTER COLUMN id SET DEFAULT nextval('module_refs_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY module_runs ALTER COLUMN id SET DEFAULT nextval('module_runs_id_seq'::regclass);
 
 
 --
@@ -2164,6 +2257,14 @@ ALTER TABLE ONLY api_keys
 
 
 --
+-- Name: automatic_exploitation_matches_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY automatic_exploitation_matches
+    ADD CONSTRAINT automatic_exploitation_matches_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -2313,6 +2414,14 @@ ALTER TABLE ONLY module_platforms
 
 ALTER TABLE ONLY module_refs
     ADD CONSTRAINT module_refs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: module_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY module_runs
+    ADD CONSTRAINT module_runs_pkey PRIMARY KEY (id);
 
 
 --
@@ -2545,6 +2654,13 @@ ALTER TABLE ONLY wmap_targets
 
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_automatic_exploitation_matches_on_ref_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_automatic_exploitation_matches_on_ref_id ON automatic_exploitation_matches USING btree (module_detail_id);
 
 
 --
@@ -3000,6 +3116,12 @@ INSERT INTO schema_migrations (version) VALUES ('20130604145732');
 
 INSERT INTO schema_migrations (version) VALUES ('20130717150737');
 
+INSERT INTO schema_migrations (version) VALUES ('20131002004641');
+
+INSERT INTO schema_migrations (version) VALUES ('20131011184338');
+
+INSERT INTO schema_migrations (version) VALUES ('20131021185657');
+
 INSERT INTO schema_migrations (version) VALUES ('20140905031549');
 
 INSERT INTO schema_migrations (version) VALUES ('20150112203945');
@@ -3009,6 +3131,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150205192745');
 INSERT INTO schema_migrations (version) VALUES ('20150209195939');
 
 INSERT INTO schema_migrations (version) VALUES ('20150212214222');
+
+INSERT INTO schema_migrations (version) VALUES ('20150219173821');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -61,42 +61,6 @@ ALTER SEQUENCE api_keys_id_seq OWNED BY api_keys.id;
 
 
 --
--- Name: automatic_exploitation_matches; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE automatic_exploitation_matches (
-    id integer NOT NULL,
-    module_detail_id integer,
-    state character varying(255),
-    nexpose_data_vulnerability_definition_id integer,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    match_set_id integer,
-    matchable_type character varying(255),
-    matchable_id integer
-);
-
-
---
--- Name: automatic_exploitation_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE automatic_exploitation_matches_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: automatic_exploitation_matches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE automatic_exploitation_matches_id_seq OWNED BY automatic_exploitation_matches.id;
-
-
---
 -- Name: clients; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -779,7 +743,7 @@ CREATE TABLE module_runs (
     fail_detail text,
     fail_reason character varying(255),
     module_detail_id integer,
-    module_name text,
+    module_full_name text,
     port integer,
     proto character varying(255),
     session_id integer,
@@ -1904,13 +1868,6 @@ ALTER TABLE ONLY api_keys ALTER COLUMN id SET DEFAULT nextval('api_keys_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY automatic_exploitation_matches ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_matches_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY clients ALTER COLUMN id SET DEFAULT nextval('clients_id_seq'::regclass);
 
 
@@ -2256,14 +2213,6 @@ ALTER TABLE ONLY workspaces ALTER COLUMN id SET DEFAULT nextval('workspaces_id_s
 
 ALTER TABLE ONLY api_keys
     ADD CONSTRAINT api_keys_pkey PRIMARY KEY (id);
-
-
---
--- Name: automatic_exploitation_matches_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY automatic_exploitation_matches
-    ADD CONSTRAINT automatic_exploitation_matches_pkey PRIMARY KEY (id);
 
 
 --
@@ -2656,13 +2605,6 @@ ALTER TABLE ONLY wmap_targets
 
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_pkey PRIMARY KEY (id);
-
-
---
--- Name: index_automatic_exploitation_matches_on_ref_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE INDEX index_automatic_exploitation_matches_on_ref_id ON automatic_exploitation_matches USING btree (module_detail_id);
 
 
 --
@@ -3131,12 +3073,6 @@ INSERT INTO schema_migrations (version) VALUES ('20130531144949');
 INSERT INTO schema_migrations (version) VALUES ('20130604145732');
 
 INSERT INTO schema_migrations (version) VALUES ('20130717150737');
-
-INSERT INTO schema_migrations (version) VALUES ('20131002004641');
-
-INSERT INTO schema_migrations (version) VALUES ('20131011184338');
-
-INSERT INTO schema_migrations (version) VALUES ('20131021185657');
 
 INSERT INTO schema_migrations (version) VALUES ('20140905031549');
 

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -1188,7 +1188,8 @@ CREATE TABLE sessions (
     closed_at timestamp without time zone,
     close_reason character varying(255),
     local_id integer,
-    last_seen timestamp without time zone
+    last_seen timestamp without time zone,
+    module_run_id integer
 );
 
 
@@ -2846,6 +2847,13 @@ CREATE INDEX index_services_on_state ON services USING btree (state);
 
 
 --
+-- Name: index_sessions_on_module_run_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_sessions_on_module_run_id ON sessions USING btree (module_run_id);
+
+
+--
 -- Name: index_vulns_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3133,6 +3141,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150209195939');
 INSERT INTO schema_migrations (version) VALUES ('20150212214222');
 
 INSERT INTO schema_migrations (version) VALUES ('20150219173821');
+
+INSERT INTO schema_migrations (version) VALUES ('20150219215039');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -455,7 +455,8 @@ CREATE TABLE loots (
     updated_at timestamp without time zone NOT NULL,
     content_type character varying(255),
     name text,
-    info text
+    info text,
+    module_run_id integer
 );
 
 
@@ -774,19 +775,19 @@ ALTER SEQUENCE module_refs_id_seq OWNED BY module_refs.id;
 
 CREATE TABLE module_runs (
     id integer NOT NULL,
-    trackable_type character varying(255),
-    trackable_id integer,
     attempted_at timestamp without time zone,
-    session_id integer,
+    fail_detail text,
+    fail_reason character varying(255),
+    module_detail_id integer,
+    module_name text,
     port integer,
     proto character varying(255),
-    fail_detail text,
+    session_id integer,
     status character varying(255),
-    username character varying(255),
+    trackable_id integer,
+    trackable_type character varying(255),
     user_id integer,
-    fail_reason character varying(255),
-    module_name text,
-    module_detail_id integer,
+    username character varying(255),
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -2707,6 +2708,13 @@ CREATE UNIQUE INDEX index_hosts_on_workspace_id_and_address ON hosts USING btree
 
 
 --
+-- Name: index_loots_on_module_run_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_loots_on_module_run_id ON loots USING btree (module_run_id);
+
+
+--
 -- Name: index_module_actions_on_module_detail_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3143,6 +3151,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150212214222');
 INSERT INTO schema_migrations (version) VALUES ('20150219173821');
 
 INSERT INTO schema_migrations (version) VALUES ('20150219215039');
+
+INSERT INTO schema_migrations (version) VALUES ('20150226151459');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 

--- a/spec/factories/module_runs.rb
+++ b/spec/factories/module_runs.rb
@@ -24,7 +24,7 @@ FactoryGirl.define do
     fail_detail "Failed to execute payload froamasher"
     status MetasploitDataModels::ModuleRun::SUCCEED
     username "joefoo"
-    module_name "exploit/windows/happy-stack-smasher"
+    module_full_name "exploit/windows/happy-stack-smasher"
   end
 end
 

--- a/spec/factories/module_runs.rb
+++ b/spec/factories/module_runs.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :module_run do
+    trackable_type "MyString"
+    trackable_id 1
+    attempted_at "2015-02-19 11:38:21"
+    session_id 1
+    port 1
+    proto "MyString"
+    fail_detail "MyText"
+    status "MyString"
+    username "MyString"
+    user_id 1
+    module_name "exploit/windows/happy-stack-smasher"
+  end
+end
+

--- a/spec/factories/module_runs.rb
+++ b/spec/factories/module_runs.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   sequence(:session_id)
 
-  factory :module_run, class: MetasploitDataModels::ModuleRun do
+  factory :metasploit_data_models_module_run, class: MetasploitDataModels::ModuleRun do
 
     association :user, factory: :mdm_user
 

--- a/spec/factories/module_runs.rb
+++ b/spec/factories/module_runs.rb
@@ -1,15 +1,29 @@
 FactoryGirl.define do
-  factory :module_run do
-    trackable_type "MyString"
-    trackable_id 1
-    attempted_at "2015-02-19 11:38:21"
+  sequence(:session_id)
+
+  factory :module_run, class: MetasploitDataModels::ModuleRun do
+
+    association :user, factory: :mdm_user
+
+    trait :failed do
+      status MetasploitDataModels::ModuleRun::FAIL
+    end
+
+    trait :exploited do
+      status MetasploitDataModels::ModuleRun::SUCCEED
+    end
+
+    trait :error do
+      status MetasploitDataModels::ModuleRun::ERROR
+    end
+
+    attempted_at Time.now
     session_id 1
-    port 1
-    proto "MyString"
-    fail_detail "MyText"
-    status "MyString"
-    username "MyString"
-    user_id 1
+    port { generate(:port) }
+    proto "http"
+    fail_detail "Failed to execute payload froamasher"
+    status MetasploitDataModels::ModuleRun::SUCCEED
+    username "joefoo"
     module_name "exploit/windows/happy-stack-smasher"
   end
 end


### PR DESCRIPTION
### Verification


- [x] `rake spec`
- [x] Verify: all specs pass
- [x] `cd spec/dummy`
- [x] `rails c --sandbox`
- [x] Avoid explosion from Rex dep: `class Mdm::Workspace; def valid_ip_or_range?(ip); true; end; end;`
- [x] `m = FactoryGirl.build(:metasploit_data_models_module_run)`

#### Validate target_session logic

- [x] `m.module_full_name = "exploit/windows/happy-stack-smasher"`
- [x] `m.target_session = FactoryGirl.create(:mdm_session)`
- [x] Verify: `m.valid? == false`
- [x] Verify: `m.errors.messages[:base].include? "target_session cannot be set for exploit modules. Use spawned_session."`

#### Validate spawned_session logic

- [x] `m.module_full_name = "post/multi/gather/minecraft-maps"`
- [x] `m.spawned_session = FactoryGirl.create(:mdm_session)`
- [x] Verify: `m.valid? == false`
- [x] Verify: `m.errors.messages[:base].include? "spawned_session cannot be set for non-exploit modules. Use target_session."`

#### Validate docs

- [x] `rake yard`
- [x] Open `doc/index.html` and navigate to the ModuleRun class
- [x] Validate: overview makes sense
- [x] Validate: diagram shows polymorphic "trackable" reationship to Mdm::Vuln and Mdm::Host