### PR TITLE
MSP-12143: Move auto exploitation MatchResult

### DIFF
--- a/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
@@ -1,0 +1,31 @@
+class MetasploitDataModels::AutomaticExploitation::MatchResult < ActiveRecord::Base
+  attr_accessible :match_id, :run_id, :state
+
+  # Match results are in one of two states:
+  #  - "succeeded" (exploit gained access)
+  #  - "failed" (exploit did NOT gain access)
+  VALID_STATES = ["succeeded", "failed"]
+
+  #
+  # ASSOCIATIONS
+  #
+
+  belongs_to :match, class_name: '::MetasploitDataModels::AutomaticExploitation::Match', dependent: :destroy
+
+  #
+  # VALIDATIONS
+  #
+
+  # must be present and one of allowable values
+  validates :state,
+            presence: true,
+            inclusion: VALID_STATES
+
+  #
+  # SCOPES
+  #
+  scope :succeeded, where(state:"succeeded")
+  scope :failed, where(state:"failed")
+
+  Metasploit::Concern.run(self)
+end

--- a/db/migrate/20131017150735_create_automatic_exploitation_match_results.rb
+++ b/db/migrate/20131017150735_create_automatic_exploitation_match_results.rb
@@ -1,0 +1,11 @@
+class CreateAutomaticExploitationMatchResults < ActiveRecord::Migration
+  def change
+    create_table :automatic_exploitation_match_results do |t|
+      t.integer :match_id
+      t.integer :run_id
+      t.string :state, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The patch number, scoped to the {MINOR} version number.
     PATCH = 1
 
-    PRERELEASE='automatic-exploitation-migration'
+    PRERELEASE='move-auto-exploitation-matchresult'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/metasploit_data_models/automatic_exploitation/match_result_spec.rb
+++ b/spec/app/models/metasploit_data_models/automatic_exploitation/match_result_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe MetasploitDataModels::AutomaticExploitation::MatchResult do
+  it_should_behave_like 'Metasploit::Concern.run'
+end

--- a/spec/app/models/metasploit_data_models/automatic_exploitation/match_spec.rb
+++ b/spec/app/models/metasploit_data_models/automatic_exploitation/match_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe MetasploitDataModels::AutomaticExploitation::Match do
+  it_should_behave_like 'Metasploit::Concern.run'
+end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -61,6 +61,39 @@ ALTER SEQUENCE api_keys_id_seq OWNED BY api_keys.id;
 
 
 --
+-- Name: automatic_exploitation_match_results; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE automatic_exploitation_match_results (
+    id integer NOT NULL,
+    match_id integer,
+    run_id integer,
+    state character varying(255) NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: automatic_exploitation_match_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE automatic_exploitation_match_results_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: automatic_exploitation_match_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE automatic_exploitation_match_results_id_seq OWNED BY automatic_exploitation_match_results.id;
+
+
+--
 -- Name: automatic_exploitation_matches; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -1858,6 +1891,13 @@ ALTER TABLE ONLY api_keys ALTER COLUMN id SET DEFAULT nextval('api_keys_id_seq':
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY automatic_exploitation_match_results ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_match_results_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY automatic_exploitation_matches ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_matches_id_seq'::regclass);
 
 
@@ -2203,6 +2243,14 @@ ALTER TABLE ONLY workspaces ALTER COLUMN id SET DEFAULT nextval('workspaces_id_s
 
 ALTER TABLE ONLY api_keys
     ADD CONSTRAINT api_keys_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automatic_exploitation_match_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY automatic_exploitation_match_results
+    ADD CONSTRAINT automatic_exploitation_match_results_pkey PRIMARY KEY (id);
 
 
 --
@@ -3053,6 +3101,8 @@ INSERT INTO schema_migrations (version) VALUES ('20130717150737');
 INSERT INTO schema_migrations (version) VALUES ('20131002004641');
 
 INSERT INTO schema_migrations (version) VALUES ('20131011184338');
+
+INSERT INTO schema_migrations (version) VALUES ('20131017150735');
 
 INSERT INTO schema_migrations (version) VALUES ('20131021185657');
 


### PR DESCRIPTION
## Verification
( land this if the corresponding Pro PR passes )

## Post-Merge steps
- [ ] Edit `lib/metasploit_data_models/version.rb` and change PRERELEASE constant to match the staging branch name: `staging/automatic-exploitation-migration`
- [ ] Commit and push on staging branch to get all specs passing
