### PR TITLE
Feature/msp 12172/move auto exploitation run

### DIFF
--- a/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
@@ -10,7 +10,12 @@ class MetasploitDataModels::AutomaticExploitation::MatchResult < ActiveRecord::B
   # ASSOCIATIONS
   #
 
-  belongs_to :match, class_name: '::MetasploitDataModels::AutomaticExploitation::Match', dependent: :destroy
+  belongs_to :match,
+             class_name: 'MetasploitDataModels::AutomaticExploitation::Match',
+             dependent: :destroy
+
+  belongs_to :run,
+             class_name: 'MetasploitDataModels::AutomaticExploitation::Run'
 
   #
   # VALIDATIONS

--- a/app/models/metasploit_data_models/automatic_exploitation/match_set.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match_set.rb
@@ -1,0 +1,10 @@
+class MetasploitDataModels::AutomaticExploitation::MatchSet < ActiveRecord::Base
+  attr_accessible :user_id, :workspace_id, :minimum_rank
+
+  has_many :runs, class_name: "MetasploitDataModels::AutomaticExploitation::Run"
+  has_many :matches, class_name: "MetasploitDataModels::AutomaticExploitation::Match", dependent: :destroy
+  belongs_to :workspace, class_name: "Mdm::Workspace"
+  belongs_to :user, class_name: "Mdm::User"
+
+  Metasploit::Concern.run(self)
+end

--- a/app/models/metasploit_data_models/automatic_exploitation/run.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/run.rb
@@ -9,19 +9,6 @@ class MetasploitDataModels::AutomaticExploitation::Run < ActiveRecord::Base
 
   has_many :match_results, class_name:'::MetasploitDataModels::AutomaticExploitation::MatchResult'
 
-  state_machine :state, initial: :not_yet_started do
-    event :start do
-      transition [:not_yet_started] => :running
-    end
-
-    event :finish do
-      transition [:running] => :finished
-    end
-
-    event :error_out do
-      transition [:running] => :failed
-    end
-  end
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/metasploit_data_models/automatic_exploitation/run.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/run.rb
@@ -1,0 +1,27 @@
+class MetasploitDataModels::AutomaticExploitation::Run < ActiveRecord::Base
+  attr_accessible :user_id, :workspace_id, :match_set_id
+
+  #
+  # ASSOCIATIONS
+  #
+  belongs_to :user, class_name: "Mdm::User"
+  belongs_to :workspace, class_name: "Mdm::Workspace"
+
+  has_many :match_results, class_name:'::MetasploitDataModels::AutomaticExploitation::MatchResult'
+
+  state_machine :state, initial: :not_yet_started do
+    event :start do
+      transition [:not_yet_started] => :running
+    end
+
+    event :finish do
+      transition [:running] => :finished
+    end
+
+    event :error_out do
+      transition [:running] => :failed
+    end
+  end
+
+  Metasploit::Concern.run(self)
+end

--- a/db/migrate/20131002164449_create_automatic_exploitation_match_sets.rb
+++ b/db/migrate/20131002164449_create_automatic_exploitation_match_sets.rb
@@ -1,0 +1,12 @@
+class CreateAutomaticExploitationMatchSets < ActiveRecord::Migration
+  def change
+    create_table :automatic_exploitation_match_sets do |t|
+      t.integer :workspace_id
+      t.integer :user_id
+
+      t.timestamps
+    end
+    add_index :automatic_exploitation_match_sets, :user_id
+    add_index :automatic_exploitation_match_sets, :workspace_id
+  end
+end

--- a/db/migrate/20131008213344_create_automatic_exploitation_runs.rb
+++ b/db/migrate/20131008213344_create_automatic_exploitation_runs.rb
@@ -1,0 +1,11 @@
+class CreateAutomaticExploitationRuns < ActiveRecord::Migration
+  def change
+    create_table :automatic_exploitation_runs do |t|
+      t.integer :workspace_id
+      t.integer :user_id
+      t.integer :match_set_id
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,9 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 23
     # The patch number, scoped to the {MINOR} version number.
-    PATCH = 1
+    PATCH = 2
 
-    PRERELEASE='automatic-exploitation-migration'
+    PRERELEASE='move-auto-exploitation-run'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -94,6 +94,38 @@ ALTER SEQUENCE automatic_exploitation_match_results_id_seq OWNED BY automatic_ex
 
 
 --
+-- Name: automatic_exploitation_match_sets; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE automatic_exploitation_match_sets (
+    id integer NOT NULL,
+    workspace_id integer,
+    user_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: automatic_exploitation_match_sets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE automatic_exploitation_match_sets_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: automatic_exploitation_match_sets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE automatic_exploitation_match_sets_id_seq OWNED BY automatic_exploitation_match_sets.id;
+
+
+--
 -- Name: automatic_exploitation_matches; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -127,6 +159,39 @@ CREATE SEQUENCE automatic_exploitation_matches_id_seq
 --
 
 ALTER SEQUENCE automatic_exploitation_matches_id_seq OWNED BY automatic_exploitation_matches.id;
+
+
+--
+-- Name: automatic_exploitation_runs; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE automatic_exploitation_runs (
+    id integer NOT NULL,
+    workspace_id integer,
+    user_id integer,
+    match_set_id integer,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: automatic_exploitation_runs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE automatic_exploitation_runs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: automatic_exploitation_runs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE automatic_exploitation_runs_id_seq OWNED BY automatic_exploitation_runs.id;
 
 
 --
@@ -1898,7 +1963,21 @@ ALTER TABLE ONLY automatic_exploitation_match_results ALTER COLUMN id SET DEFAUL
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY automatic_exploitation_match_sets ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_match_sets_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY automatic_exploitation_matches ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_matches_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY automatic_exploitation_runs ALTER COLUMN id SET DEFAULT nextval('automatic_exploitation_runs_id_seq'::regclass);
 
 
 --
@@ -2254,11 +2333,27 @@ ALTER TABLE ONLY automatic_exploitation_match_results
 
 
 --
+-- Name: automatic_exploitation_match_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY automatic_exploitation_match_sets
+    ADD CONSTRAINT automatic_exploitation_match_sets_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: automatic_exploitation_matches_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
 --
 
 ALTER TABLE ONLY automatic_exploitation_matches
     ADD CONSTRAINT automatic_exploitation_matches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automatic_exploitation_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY automatic_exploitation_runs
+    ADD CONSTRAINT automatic_exploitation_runs_pkey PRIMARY KEY (id);
 
 
 --
@@ -2643,6 +2738,20 @@ ALTER TABLE ONLY wmap_targets
 
 ALTER TABLE ONLY workspaces
     ADD CONSTRAINT workspaces_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_automatic_exploitation_match_sets_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_automatic_exploitation_match_sets_on_user_id ON automatic_exploitation_match_sets USING btree (user_id);
+
+
+--
+-- Name: index_automatic_exploitation_match_sets_on_workspace_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_automatic_exploitation_match_sets_on_workspace_id ON automatic_exploitation_match_sets USING btree (workspace_id);
 
 
 --
@@ -3099,6 +3208,10 @@ INSERT INTO schema_migrations (version) VALUES ('20130604145732');
 INSERT INTO schema_migrations (version) VALUES ('20130717150737');
 
 INSERT INTO schema_migrations (version) VALUES ('20131002004641');
+
+INSERT INTO schema_migrations (version) VALUES ('20131002164449');
+
+INSERT INTO schema_migrations (version) VALUES ('20131008213344');
 
 INSERT INTO schema_migrations (version) VALUES ('20131011184338');
 


### PR DESCRIPTION
__note: it became obvious in doing this that MatchSet would need to be moved as well, so that is included in this PR__

## Verification
- [x] Verify: associated Pro PR (https://github.com/rapid7/pro/pull/1868) passes Jenkins and is landed
- [x] `rake spec`
- [x] Verify: no failures


## Post-Merge Steps
- [x] edit `lib/metasploit_data_models/version.rb` and change PRERELEASE to match the staging branch name
- [ ] `rake spec`
- [ ] Verify all specs pass
- [ ] `git push origin staging/automatic-exploitation-migration`