### PR TITLE
MSP-12307: Rename indices to match for rails 4

### DIFF
--- a/db/migrate/20150317145455_rename_module_indices.rb
+++ b/db/migrate/20150317145455_rename_module_indices.rb
@@ -1,0 +1,25 @@
+class RenameModuleIndices < ActiveRecord::Migration
+  def change
+    rename_index :module_actions,
+                 :index_module_actions_on_detail_id,
+                 :index_module_actions_on_module_detail_id
+    rename_index :module_archs,
+                 :index_module_archs_on_detail_id,
+                 :index_module_archs_on_module_detail_id
+    rename_index :module_authors,
+                 :index_module_authors_on_detail_id,
+                 :index_module_authors_on_module_detail_id
+    rename_index :module_mixins,
+                 :index_module_mixins_on_detail_id,
+                 :index_module_mixins_on_module_detail_id
+    rename_index :module_platforms,
+                 :index_module_platforms_on_detail_id,
+                 :index_module_platforms_on_module_detail_id
+    rename_index :module_refs,
+                 :index_module_refs_on_detail_id,
+                 :index_module_refs_on_module_detail_id
+    rename_index :module_targets,
+                 :index_module_targets_on_detail_id,
+                 :index_module_targets_on_module_detail_id
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 1
 
-    PRERELEASE = 'rails-4.0'
+    PRERELEASE = 'rename-indices'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -3010,6 +3010,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150209195939');
 
 INSERT INTO schema_migrations (version) VALUES ('20150212214222');
 
+INSERT INTO schema_migrations (version) VALUES ('20150317145455');
+
 INSERT INTO schema_migrations (version) VALUES ('21');
 
 INSERT INTO schema_migrations (version) VALUES ('22');


### PR DESCRIPTION
Rename some index names that are causing build failures for rails 4 framework upgrade on Travis.