### PR TITLE
Update to metasploit-concern 0.4.0

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -7,6 +7,8 @@ module MetasploitDataModels
     MINOR = 23
     # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 3
+    # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+    PRERELEASE = 'app-concerns-eager-load'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   # os fingerprinting
   s.add_runtime_dependency 'recog', '~> 1.0'
 
-  s.add_runtime_dependency 'metasploit-concern', '~> 0.3.0'
+  s.add_runtime_dependency 'metasploit-concern', '0.4.0.pre.app.pre.concerns.pre.eager.pre.load'
   s.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   s.add_runtime_dependency 'railties', '< 4.0.0'
 

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   # os fingerprinting
   s.add_runtime_dependency 'recog', '~> 1.0'
 
-  s.add_runtime_dependency 'metasploit-concern', '0.4.0.pre.app.pre.concerns.pre.eager.pre.load'
+  s.add_runtime_dependency 'metasploit-concern', '0.4.0'
   s.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   s.add_runtime_dependency 'railties', '< 4.0.0'
 


### PR DESCRIPTION
MSP-12550

Update to use metasploit-concern 0.4.0

# Pre-verification Steps
- [x] Merge https://github.com/rapid7/metasploit-concern/pull/14

# Verification Steps

- [x] `rm Gemfile.lock`
- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

Complete these steps on master

## Version

### Compatible changes

If the change are compatible with the previous branch's API, then increment [`PATCH`](lib/metasploit_data_models/version.rb).

### Incompatible changes

If your changes are incompatible with the previous branch's API, then increment
[`MINOR`](lib/metasploit_data_models/version.rb) and reset [`PATCH`](lib/metasploit_data_models/version.rb) to `0`.

- [ ] Following the rules for [semantic versioning 2.0](http://semver.org/spec/v2.0.0.html), update
[`MINOR`](lib/metasploit_data_models/version.rb) and [`PATCH`](lib/metasploit_data_models/version.rb) and commit the changes.

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`