### PR TITLE
Create migration to rename an AE match index

### DIFF
--- a/db/migrate/20150421211719_rename_automatic_exploitation_index.rb
+++ b/db/migrate/20150421211719_rename_automatic_exploitation_index.rb
@@ -1,7 +1,16 @@
 class RenameAutomaticExploitationIndex < ActiveRecord::Migration
-  def change
-    rename_index :automatic_exploitation_matches,
-    'index_automatic_exploitation_matches_on_ref_id',
-    'index_automatic_exploitation_matches_on_module_detail_id'
+  def up
+    if index_name_exists? :automatic_exploitation_matches, :index_automatic_exploitation_matches_on_ref_id, false
+      rename_index :automatic_exploitation_matches,
+      :index_automatic_exploitation_matches_on_ref_id,
+      :index_automatic_exploitation_matches_on_module_detail_id
+    end
+  end
+  def down
+    if index_name_exists? :automatic_exploitation_matches, :index_automatic_exploitation_matches_on_module_detail_id, false
+      rename_index :automatic_exploitation_matches,
+      :index_automatic_exploitation_matches_on_module_detail_id,
+      :index_automatic_exploitation_matches_on_ref_id
+    end
   end
 end

--- a/db/migrate/20150421211719_rename_automatic_exploitation_index.rb
+++ b/db/migrate/20150421211719_rename_automatic_exploitation_index.rb
@@ -1,0 +1,7 @@
+class RenameAutomaticExploitationIndex < ActiveRecord::Migration
+  def change
+    rename_index :automatic_exploitation_matches,
+    'index_automatic_exploitation_matches_on_ref_id',
+    'index_automatic_exploitation_matches_on_module_detail_id'
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,7 @@ module MetasploitDataModels
     # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
     # PRERELEASE =
 
-    PRERELEASE = 'rails-4.0'
+    PRERELEASE = 'rename-ae-index'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -3379,6 +3379,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150317145455');
 
 INSERT INTO schema_migrations (version) VALUES ('20150326183742');
 
+INSERT INTO schema_migrations (version) VALUES ('20150421211719');
+
 INSERT INTO schema_migrations (version) VALUES ('21');
 
 INSERT INTO schema_migrations (version) VALUES ('22');


### PR DESCRIPTION
MSP-12593

* Fixes structure.sql diffs
* Used to be ref_id but new naming convention for AE is module_detail_id

## Verification Steps

First run migrations on master. In mdm:
- [x] `git checkout master`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake db:drop:all db:create:all db:migrate`
Then checkout staging/rails-4.0 and continue new migrations:
- [x] `git fetch origin`
- [x] `git checkout bug/MSP-12593/rename-ae-index`
- [x] `git merge staging/rails-4.0`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake db:migrate`
- [x] verify structure.sql has no diffs

# Post-merge Steps

## Testing
- [x] `git checkout staging/rails-4.0`
- [x] `rake db:drop:all db:create:all db:migrate`
- [x] VERIFY no failures

Perform these steps prior to pushing to DESTINATION or the build will be broke on DESTINATION.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Change `PRERELEASE` from `SOURCE_SUMMARY` to `DESTINATION_SUMMARY` to match the branch (DESTINATION) summary (DESTINATION_SUMMARY)

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the prerelease suffix has change on the gem.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin DESTINATION`