### PR TITLE
Upgrade to rspec-3.1

### DIFF
--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'recog', '~> 1.0'
 
   s.add_runtime_dependency 'metasploit-concern', '0.4.0'
-  s.add_runtime_dependency 'metasploit-model', '= 0.30.1.pre.rspec.pre.3.pre.1'
+  s.add_runtime_dependency 'metasploit-model', '~> 0.30.2'
   s.add_runtime_dependency 'railties', '< 4.0.0'
 
   # arel-helpers: Useful tools to help construct database queries with ActiveRecord and Arel.


### PR DESCRIPTION
MSP-12669

# Pre-verification Steps
- [x] Merge https://github.com/rapid7/metasploit-model/pull/39
- [x] Update version of `metasploit-model` in `metasploit_data_models.gemspec` to be `~> <released-version>`.

# Verification Steps

- [x] `rm Gemfile.lock`
- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Release

Complete these steps on master

## Version

### Compatible changes

- Incremented [`PATCH`](lib/metasploit_data_models/version.rb).

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [x] `rvm use ruby-2.1@metasploit_data_models`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake release`