### PR TITLE
Fix factory_girl deprecation warning by converting ignore to transient

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,9 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 24
     # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 0
+    PATCH = 1
     # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-    # PRERELEASE =
+    PRERELEASE = 'ignore-to-transient'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/factories/mdm/module/details.rb
+++ b/spec/factories/mdm/module/details.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :mdm_module_detail, :class => Mdm::Module::Detail do
-    ignore do
+    transient do
       root {
         MetasploitDataModels.root
       }


### PR DESCRIPTION
MSP-12678

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] **Verify** `DEPRECATION WARNING: `#ignore` is deprecated and will be removed in 5.0. Please use `#transient` instead.` is NOT printed
- [x] **Verify** no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## Version

### Compatible changes

- Incremented [`PATCH`](lib/metasploit_data_models/version.rb).

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`