### PR TITLE
Fix shoulda matchers deprecations

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,9 +6,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 24
     # The patch number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 0
+    PATCH = 1
     # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-    # PRERELEASE =
+    PRERELEASE = 'shoulda-matchers-deprecations'
 
     # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the `PRERELEASE` in the
     # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/app/models/mdm/host_spec.rb
+++ b/spec/app/models/mdm/host_spec.rb
@@ -380,7 +380,7 @@ describe Mdm::Host do
 
   context 'validations' do
     context 'address' do
-      it { should ensure_exclusion_of(:address).in_array(['127.0.0.1']) }
+      it { should validate_exclusion_of(:address).in_array(['127.0.0.1']) }
       it { should validate_presence_of(:address) }
 
       # can't use validate_uniqueness_of(:address).scoped_to(:workspace_id) because it will attempt to set workspace_id

--- a/spec/app/models/mdm/host_spec.rb
+++ b/spec/app/models/mdm/host_spec.rb
@@ -416,7 +416,7 @@ describe Mdm::Host do
         end
       end
     end
-    it { should ensure_inclusion_of(:state).in_array(states).allow_nil }
+    it { should validate_inclusion_of(:state).in_array(states).allow_nil }
     it { should validate_presence_of(:workspace) }
   end
 

--- a/spec/app/models/mdm/module/detail_spec.rb
+++ b/spec/app/models/mdm/module/detail_spec.rb
@@ -173,14 +173,14 @@ describe Mdm::Module::Detail do
   end
 
   context 'validations' do
-    it { should ensure_inclusion_of(:mtype).in_array(types) }
+    it { should validate_inclusion_of(:mtype).in_array(types) }
 
     # Because the boolean field will cast most strings to false,
-    # ensure_inclusion_of(:privileged).in_array([true, false]) will fail on the disallowed values check.
+    # validate_inclusion_of(:privileged).in_array([true, false]) will fail on the disallowed values check.
 
     context 'rank' do
       it { should validate_numericality_of(:rank).only_integer }
-      it { should ensure_inclusion_of(:rank).in_array(ranks) }
+      it { should validate_inclusion_of(:rank).in_array(ranks) }
     end
 
     it { should validate_presence_of(:refname) }

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -152,7 +152,7 @@ describe Mdm::Service do
     }
 
     it { should validate_numericality_of(:port).only_integer }
-    it { should ensure_inclusion_of(:proto).in_array(described_class::PROTOS) }
+    it { should validate_inclusion_of(:proto).in_array(described_class::PROTOS) }
 
     context 'when a duplicate service already exists' do
       let(:service1) { FactoryGirl.create(:mdm_service)}

--- a/spec/app/models/mdm/web_vuln_spec.rb
+++ b/spec/app/models/mdm/web_vuln_spec.rb
@@ -111,8 +111,8 @@ describe Mdm::WebVuln do
 
   context 'validations' do
     it { should validate_presence_of :category }
-    it { should ensure_inclusion_of(:confidence).in_range(confidence_range) }
-    it { should ensure_inclusion_of(:method).in_array(methods) }
+    it { should validate_inclusion_of(:confidence).in_range(confidence_range) }
+    it { should validate_inclusion_of(:method).in_array(methods) }
     it { should validate_presence_of :name }
     it { should validate_presence_of :path }
 
@@ -281,7 +281,7 @@ describe Mdm::WebVuln do
     end
 
     it { should validate_presence_of :proof }
-    it { should ensure_inclusion_of(:risk).in_range(risk_range) }
+    it { should validate_inclusion_of(:risk).in_range(risk_range) }
     it { should validate_presence_of :web_site }
   end
 

--- a/spec/app/models/mdm/workspace_spec.rb
+++ b/spec/app/models/mdm/workspace_spec.rb
@@ -140,11 +140,11 @@ describe Mdm::Workspace do
     end
 
     context 'description' do
-      it { should ensure_length_of(:description).is_at_most(4 * (2 ** 10)) }
+      it { should validate_length_of(:description).is_at_most(4 * (2 ** 10)) }
     end
 
     context 'name' do
-      it { should ensure_length_of(:name).is_at_most(2**8 - 1) }
+      it { should validate_length_of(:name).is_at_most(2**8 - 1) }
       it { should validate_presence_of :name }
       it { should validate_uniqueness_of :name }
     end

--- a/spec/app/models/metasploit_data_models/search/operation/port/number_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/operation/port/number_spec.rb
@@ -36,6 +36,6 @@ describe MetasploitDataModels::Search::Operation::Port::Number do
   end
 
   context 'validations' do
-    it { should ensure_inclusion_of(:value).in_range(described_class::RANGE) }
+    it { should validate_inclusion_of(:value).in_range(described_class::RANGE) }
   end
 end

--- a/spec/app/models/metasploit_data_models/search/operator/multitext_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/operator/multitext_spec.rb
@@ -12,7 +12,7 @@ describe MetasploitDataModels::Search::Operator::Multitext do
   }
 
   context 'validations' do
-    it { should ensure_length_of(:operator_names).is_at_least(2) }
+    it { should validate_length_of(:operator_names).is_at_least(2) }
     it { should validate_presence_of :name }
   end
 


### PR DESCRIPTION
MSP-12679

# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] **Verify** `Warning from shoulda-matchers` is NOT printed.
- [ ] **Verify** no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## Version

### Compatible changes

- Incremented [`PATCH`](lib/metasploit_data_models/version.rb).

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`