### PR TITLE
Fix build failures due to undocumented objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,14 @@ Make your changes or however many commits you like, committing each with `git co
 
 ### Pre-Pull Request Testing
 
+#### Specs
 1. Run specs one last time before opening the Pull Request: `rake spec`
 2. Verify there was no failures.
+
+#### Documentation
+1. Generate yard documentation to ensure all new code is documented: `rake yard`
+2. Verify there were no `[warn]`ings.
+3. Verify there were no undocumented objects.
 
 ### Push
 
@@ -60,6 +66,11 @@ Push your branch to your fork on github: `git push TYPE/ISSUE/SUMMARY`
 ## `rake spec`
 - [ ] `rake spec`
 - [ ] VERIFY no failures
+
+## `rake yard`
+- [ ] `rake yard`
+- [ ] VERIFY no `[warn]`ings
+- [ ] VERIFY no undocumented objects
 ```
 
 You should also include at least one scenario to manually check the changes outside of specs.

--- a/app/models/mdm/wmap_request.rb
+++ b/app/models/mdm/wmap_request.rb
@@ -84,17 +84,18 @@ class Mdm::WmapRequest < ActiveRecord::Base
   # @!endgroup
   #
 
-  Metasploit::Concern.run(self)
-
   #
-  # Attributes
+  # Instance Methods
   #
 
-  # @!attribute [rw] address
-  #   The IP address for this request. Necessary to avoid coercion to an `IPAddr` object.
+  # @note Necessary to avoid coercion to an `IPAddr` object.
   #
-  #   @return [String]
+  # The IP address for this request.
+  #
+  # @return [String]
   def address
     self[:address].to_s
   end
+
+  Metasploit::Concern.run(self)
 end

--- a/app/models/mdm/wmap_target.rb
+++ b/app/models/mdm/wmap_target.rb
@@ -39,17 +39,18 @@ class Mdm::WmapTarget < ActiveRecord::Base
   #
   #   @return [DateTime]
 
-  Metasploit::Concern.run(self)
-
   #
-  # Attributes
+  # Instance Methods
   #
 
-  # @!attribute [rw] address
-  #   The IP address for this target. Necessary to avoid coercion to an `IPAddr` object.
+  # @note Necessary to avoid coercion to an `IPAddr` object.
   #
-  #   @return [String]
+  # The IP address for this target.
+  #
+  # @return [String]
   def address
     self[:address].to_s
   end
+
+  Metasploit::Concern.run(self)
 end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 0
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 0
+    PATCH = 1
+    # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+    PRERELEASE = 'undocumented'
 
     #
     # Module Methods


### PR DESCRIPTION
MSP-12704


Fix merge error to fix undocumented object warnings from YARD that lead to build failure when YARD coverage was below 100%.

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Releasing

## Release to rubygems.org

## ruby-2.1
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`