### PR TITLE
Polymorphic relationship between Mdm::Vuln and it's origin

### DIFF
--- a/app/models/mdm/vuln.rb
+++ b/app/models/mdm/vuln.rb
@@ -30,6 +30,14 @@ class Mdm::Vuln < ActiveRecord::Base
              class_name: 'Mdm::Service',
              inverse_of: :vulns
 
+  # @!attribute [rw] origin
+  #   A polymorphic association to the origin that found
+  #   the vulnerability.
+  #
+  #   @return [ActiveRecord::Relation<origin>]
+  belongs_to :origin,
+             polymorphic: true
+
   # @!attribute [rw] vuln_attempts
   #   Attempts to exploit this vulnerability.
   #

--- a/db/migrate/20150514182921_add_origin_to_mdm_vuln.rb
+++ b/db/migrate/20150514182921_add_origin_to_mdm_vuln.rb
@@ -1,0 +1,13 @@
+class AddOriginToMdmVuln < ActiveRecord::Migration
+  def up
+    add_column :vulns, :origin_id,   :integer
+    add_column :vulns, :origin_type, :string
+
+    add_index :vulns, :origin_id
+  end
+
+  def down
+    remove_column :vulns, :origin_id
+    remove_column :vulns, :origin_type
+  end
+end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -12,6 +12,7 @@ module MetasploitDataModels
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 0
 
+    # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
     PRERELEASE = 'polymorphic-vuln-import'
     #
     # Module Methods

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,10 +8,11 @@ module MetasploitDataModels
     # The major version number.
     MAJOR = 1
     # The minor version number, scoped to the {MAJOR} version number.
-    MINOR = 0
+    MINOR = 1
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 1
+    PATCH = 0
 
+    PRERELEASE = 'polymorphic-vuln-import'
     #
     # Module Methods
     #

--- a/spec/app/models/mdm/vuln_spec.rb
+++ b/spec/app/models/mdm/vuln_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Mdm::Vuln, type: :model do
 
   context 'associations' do
     it { is_expected.to belong_to(:host).class_name('Mdm::Host') }
+    it { is_expected.to belong_to(:origin) }
     it { is_expected.to belong_to(:service).class_name('Mdm::Service') }
     it { is_expected.to have_many(:module_refs).class_name('Mdm::Module::Ref').through(:refs) }
     it { is_expected.to have_many(:module_runs).class_name('MetasploitDataModels::ModuleRun') }
@@ -128,6 +129,8 @@ RSpec.describe Mdm::Vuln, type: :model do
       it { is_expected.to have_db_column(:host_id).of_type(:integer) }
       it { is_expected.to have_db_column(:info).of_type(:string) }
       it { is_expected.to have_db_column(:name).of_type(:string) }
+      it { is_expected.to have_db_column(:origin_id).of_type(:integer) }
+      it { is_expected.to have_db_column(:origin_type).of_type(:string) }
       it { is_expected.to have_db_column(:service_id).of_type(:integer) }
 
       context 'counter caches' do

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -1659,7 +1659,9 @@ CREATE TABLE vulns (
     info character varying(65536),
     exploited_at timestamp without time zone,
     vuln_detail_count integer DEFAULT 0,
-    vuln_attempt_count integer DEFAULT 0
+    vuln_attempt_count integer DEFAULT 0,
+    origin_id integer,
+    origin_type character varying(255)
 );
 
 
@@ -3082,6 +3084,13 @@ CREATE INDEX index_vulns_on_name ON vulns USING btree (name);
 
 
 --
+-- Name: index_vulns_on_origin_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE INDEX index_vulns_on_origin_id ON vulns USING btree (origin_id);
+
+
+--
 -- Name: index_web_forms_on_path; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -3380,6 +3389,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150317145455');
 INSERT INTO schema_migrations (version) VALUES ('20150326183742');
 
 INSERT INTO schema_migrations (version) VALUES ('20150421211719');
+
+INSERT INTO schema_migrations (version) VALUES ('20150514182921');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
MSP-12395

Add polymorphic relationship between `Mdm::Vuln` and it's origin

--

# Pre-verfication steps

- [x] `cd ~/rapid7/metasploit_data_models`
- [x] `git fetch origin`
- [x] `git checkout feature/MSP-12395/polymorphic-vuln-import`
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake db:drop:all db:create:all db:migrate`

--

# Verification steps

### Specs

- [x] `rake spec`
- [x] VERIFY no failures
- [x] VERIFY test coverage greater than 92%

### Functionality

**Database Columns**

- [x] `cd spec/dummy && rails c`
- [x] `console> Mdm::Vuln.connection`
- [x] `console> Mdm::Vuln`
- [x] VERIFY column `origin_id: integer`
- [x] VERIFY column `origin_type: string`

**Polymorphic Association**

- [x] `console> vuln = FactoryGirl.create :mdm_vuln`
- [x] `console> vuln.origin`
- [x] VERIFY `origin` method is defined and returns `nil`
- [x] `console> o = FactoryGirl.create :metasploit_data_models_module_run`
- [x] `console> vuln.origin =  o`
- [x] `console> vuln.origin`
- [x] VERIFY that `origin_id` is same as `o.id`
- [x] VERIFY that `origin_type` is `"MetasploitDataModels::ModuleRun"`

### Land PR

- [x] Merge `feature/MSP-12395/polymorphic-vuln-import`

--

# Post-merge steps
### Complete these steps prior to pushing to master, or the build will be broken on master

### Version

- [ ] `git checkout master`
- [ ] `git pull`
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` constant

### Gem build

- [ ] `gem build *.gemspec`
- [ ] VERIFY the gem has no `.pre` version suffix

### RSpec

- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

### Commit & Push

- [ ] Commit (signed) changes
- [ ] `git push origin master`

--

# Release
### Complete these steps on master

### Version - compatible changes

- Incremented `MINOR`, and reset `PATCH` to 0

### JRuby

- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

### MRI Ruby

- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`
