### PR TITLE
Updates recog to 2.0, bumps version to 1.2.0

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The major version number.
     MAJOR = 1
     # The minor version number, scoped to the {MAJOR} version number.
-    MINOR = 1
+    MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 0
 

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'railties', *rails_version_constraints
 
   # os fingerprinting
-  s.add_runtime_dependency 'recog', '~> 1.0'
+  s.add_runtime_dependency 'recog', '~> 2.0'
 
   # arel-helpers: Useful tools to help construct database queries with ActiveRecord and Arel.
   s.add_runtime_dependency 'arel-helpers'


### PR DESCRIPTION
Recog has been bumped to version 2.0 for future updates. As a result, metasploit_data_models and metasploit-framework needs to be bumped as well. 