### PR TITLE
Updates recog to 2.0, bumps version to 1.2.0

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -13,6 +13,7 @@ module MetasploitDataModels
     PATCH = 0
 
     # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+    PRERELEASE = "update-recog"
 
     #
     # Module Methods

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -8,7 +8,7 @@ module MetasploitDataModels
     # The major version number.
     MAJOR = 1
     # The minor version number, scoped to the {MAJOR} version number.
-    MINOR = 1
+    MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 0
 

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'railties', *rails_version_constraints
 
   # os fingerprinting
-  s.add_runtime_dependency 'recog', '~> 1.0'
+  s.add_runtime_dependency 'recog', '~> 2.0'
 
   # arel-helpers: Useful tools to help construct database queries with ActiveRecord and Arel.
   s.add_runtime_dependency 'arel-helpers'


### PR DESCRIPTION
MSP-12735
Closes #125

Recog has been bumped to version 2.0 for future updates. As a result, metasploit_data_models and metasploit-framework needs to be bumped as well. 

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no `[warn]`ings
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`

# Releasing

## Release to rubygems.org

## ruby-2.1
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

# Post-release steps
- [ ] Update `Gemfile.lock` with released metasploit_data_models in rapid7/metasploit-framework#5399