### PR TITLE
MSP-12741: Adds by_workspace scopes back to MatchResult

### DIFF
--- a/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
@@ -56,5 +56,24 @@ class MetasploitDataModels::AutomaticExploitation::MatchResult < ActiveRecord::B
   # Runs of {#match} that succeeded
   scope :succeeded, lambda { where(state:"succeeded") }
 
+  # Runs of {#match} by workspace ID
+  scope :by_workspace, lambda { |workspace_id|
+                       joins(
+                         MetasploitDataModels::AutomaticExploitation::MatchResult.join_association(:match),
+                         MetasploitDataModels::AutomaticExploitation::Match.join_association(:match_set)
+                       ).where(
+                         MetasploitDataModels::AutomaticExploitation::MatchSet[:workspace_id].eq(workspace_id),
+                       )
+                     }
+
+  # Runs of {#match} by workspace ID and vuln ID
+  scope :by_workspace_and_vuln, lambda { |workspace_id,vuln_id|
+                                self.by_workspace(workspace_id).where(
+                                  MetasploitDataModels::AutomaticExploitation::Match[:matchable_id].eq(vuln_id),
+                                  MetasploitDataModels::AutomaticExploitation::Match[:matchable_type].eq('Mdm::Vuln')
+                                )
+                              }
+
   Metasploit::Concern.run(self)
 end
+

--- a/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
+++ b/app/models/metasploit_data_models/automatic_exploitation/match_result.rb
@@ -66,14 +66,6 @@ class MetasploitDataModels::AutomaticExploitation::MatchResult < ActiveRecord::B
                        )
                      }
 
-  # Runs of {#match} by workspace ID and vuln ID
-  scope :by_workspace_and_vuln, lambda { |workspace_id,vuln_id|
-                                self.by_workspace(workspace_id).where(
-                                  MetasploitDataModels::AutomaticExploitation::Match[:matchable_id].eq(vuln_id),
-                                  MetasploitDataModels::AutomaticExploitation::Match[:matchable_type].eq('Mdm::Vuln')
-                                )
-                              }
-
   Metasploit::Concern.run(self)
 end
 

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 0
+    PATCH = 1
+    # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version number.
+    PRERELEASE = 'vv-push-validation-fix'
 
     #
     # Module Methods


### PR DESCRIPTION
MSP-12741

## Verification Steps
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY no failures

### Pro verification
- [ ] Alter Pro Gemfile to point to MDM path on this branch
- [ ] Follow steps detailed in https://jira.tor.rapid7.com/browse/MSP-12741, verify validation push succeeds

## Post-merge Steps
Perform these steps prior to pushing to master or the build will be broke on master.

### Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

### Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

### RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

### Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

## Release
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`