### PR TITLE
Bug/msp 10957/tag char validation

### DIFF
--- a/app/models/mdm/tag.rb
+++ b/app/models/mdm/tag.rb
@@ -2,6 +2,9 @@
 class Mdm::Tag < ActiveRecord::Base
   include Metasploit::Model::Search
 
+  TAG_CHAR_VALIDATION_MSG = "Tag names can only contain alphanumeric characters, dots, dashes, and underscores."
+
+  TAG_LENGTH_VALIDATION_MSG = "desc must be less than 8k."
   #
   # Associations
   #
@@ -82,11 +85,11 @@ class Mdm::Tag < ActiveRecord::Base
   validates :desc,
             :length => {
                 :maximum => ((8 * (2 ** 10)) - 1),
-                :message => "desc must be less than 8k."
+                :message => TAG_LENGTH_VALIDATION_MSG
             }
   validates :name,
             :format => {
-                :with => /\A[A-Za-z0-9\x2e\x2d_]+\z/, :message => "Tag names can only contain alphanumeric characters, dots, dashes, and underscores."
+                :with => /\A[A-Za-z0-9\x2e\x2d_]+\z/, :message => TAG_CHAR_VALIDATION_MSG
             },
             :presence => true
 

--- a/app/models/mdm/tag.rb
+++ b/app/models/mdm/tag.rb
@@ -86,7 +86,7 @@ class Mdm::Tag < ActiveRecord::Base
             }
   validates :name,
             :format => {
-                :with => /\A[A-Za-z0-9\x2e\x2d_]+\z/, :message => "must be alphanumeric, dots, dashes, or underscores"
+                :with => /\A[A-Za-z0-9\x2e\x2d_]+\z/, :message => "Tag names can only contain alphanumeric characters, dots, dashes, and underscores."
             },
             :presence => true
 

--- a/app/models/mdm/tag.rb
+++ b/app/models/mdm/tag.rb
@@ -2,9 +2,6 @@
 class Mdm::Tag < ActiveRecord::Base
   include Metasploit::Model::Search
 
-  TAG_CHAR_VALIDATION_MSG = "Tag names can only contain alphanumeric characters, dots, dashes, and underscores."
-
-  TAG_LENGTH_VALIDATION_MSG = "desc must be less than 8k."
   #
   # Associations
   #

--- a/app/models/mdm/tag.rb
+++ b/app/models/mdm/tag.rb
@@ -85,11 +85,11 @@ class Mdm::Tag < ActiveRecord::Base
   validates :desc,
             :length => {
                 :maximum => ((8 * (2 ** 10)) - 1),
-                :message => TAG_LENGTH_VALIDATION_MSG
+                :message => I18n.t('activerecord.ancestors.mdm/tag.model.errors.messages.length')
             }
   validates :name,
             :format => {
-                :with => /\A[A-Za-z0-9\x2e\x2d_]+\z/, :message => TAG_CHAR_VALIDATION_MSG
+                :with => /\A[A-Za-z0-9\x2e\x2d_]+\z/, :message => I18n.t('activerecord.ancestors.mdm/tag.model.errors.messages.character')
             },
             :presence => true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,12 @@ en:
               os_name:
                 help: "Filters the results by operating system."
       mdm/tag:
+        model:
+          errors:
+            messages:
+              character: "Tag names can only contain alphanumeric characters, dots, dashes, and underscores."
+              length: "desc must be less than 8k."
+
         search:
           operator:
             names:

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,10 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 1
+    PATCH = 4
+
+    # The prerelease version, scoped to the {PATCH} version number.
+    PRERELEASE = "tag-char-validation"
 
     #
     # Module Methods

--- a/spec/app/models/mdm/tag_spec.rb
+++ b/spec/app/models/mdm/tag_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Mdm::Tag, type: :model do
     end
 
     context 'name' do
+      let(:error_msg) {Mdm::Tag::TAG_CHAR_VALIDATION_MSG}
       it 'must be present' do
         nameless_tag = FactoryGirl.build(:mdm_tag, :name => nil)
         expect(nameless_tag).not_to be_valid
@@ -49,19 +50,19 @@ RSpec.describe Mdm::Tag, type: :model do
         #Test for various bad inputs we should never allow
         mytag = FactoryGirl.build(:mdm_tag, :name => "A'1")
         expect(mytag).not_to be_valid
-        expect(mytag.errors[:name]).to include('must be alphanumeric, dots, dashes, or underscores')
+        expect(mytag.errors[:name]).to include(error_msg)
         mytag = FactoryGirl.build(:mdm_tag, :name => "A;1")
         expect(mytag).not_to be_valid
-        expect(mytag.errors[:name]).to include('must be alphanumeric, dots, dashes, or underscores')
+        expect(mytag.errors[:name]).to include(error_msg)
         mytag = FactoryGirl.build(:mdm_tag, :name => "A%1")
         expect(mytag).not_to be_valid
-        expect(mytag.errors[:name]).to include('must be alphanumeric, dots, dashes, or underscores')
+        expect(mytag.errors[:name]).to include(error_msg)
         mytag = FactoryGirl.build(:mdm_tag, :name => "A=1")
         expect(mytag).not_to be_valid
-        expect(mytag.errors[:name]).to include('must be alphanumeric, dots, dashes, or underscores')
+        expect(mytag.errors[:name]).to include(error_msg)
         mytag = FactoryGirl.build(:mdm_tag, :name => "#A1")
         expect(mytag).not_to be_valid
-        expect(mytag.errors[:name]).to include('must be alphanumeric, dots, dashes, or underscores')
+        expect(mytag.errors[:name]).to include(error_msg)
       end
     end
   end

--- a/spec/app/models/mdm/tag_spec.rb
+++ b/spec/app/models/mdm/tag_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Mdm::Tag, type: :model do
     end
 
     context 'name' do
-      let(:error_msg) {Mdm::Tag::TAG_CHAR_VALIDATION_MSG}
+      let(:error_msg) {I18n.t('activerecord.ancestors.mdm/tag.model.errors.messages.character')}
       it 'must be present' do
         nameless_tag = FactoryGirl.build(:mdm_tag, :name => nil)
         expect(nameless_tag).not_to be_valid


### PR DESCRIPTION
# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no `[warn]`ings
- [x] VERIFY no undocumented objects

## Pro
- [x] load pro branch bug/MSP-10957/tag-char-validation
- [x] launch with mdm built from source
- [x] head to the creds management page
- [x] select a cred core and click the "add tag" button
- [x] try to enter an invalid tag name (ie: one containing '#' or '@'
- [x] verify that you get the following error message: ```Tag names can only contain alphanumeric characters, dots, dashes, and underscores.```

# Post-merge Steps
Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`
