### PR TITLE
Ensure Match objects persist after Detail delete

### DIFF
--- a/app/models/mdm/module/detail.rb
+++ b/app/models/mdm/module/detail.rb
@@ -71,7 +71,6 @@ class Mdm::Module::Detail < ActiveRecord::Base
   #   @return [ActiveRecord::Relation<MetasploitDataModels::AutomaticExploitation::Match>]
   has_many :matches,
            :class_name => 'MetasploitDataModels::AutomaticExploitation::Match',
-           :dependent => :destroy,
            :primary_key => :fullname,
            :foreign_key => :module_fullname,
            :inverse_of => :module_detail

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 1
+    PATCH = 2
+    # Remove on master
+    PRERELEASE = 'matches-killed-on-detail-delete'
 
     #
     # Module Methods

--- a/spec/app/models/metasploit_data_models/automatic_exploitation/match_spec.rb
+++ b/spec/app/models/metasploit_data_models/automatic_exploitation/match_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MetasploitDataModels::AutomaticExploitation::Match, type: :model 
 
       subject(:automatic_exploitation_match){ described_class.new }
 
-      before(:each ) do
+      before(:each) do
         automatic_exploitation_match.matchable = vuln
         automatic_exploitation_match.module_fullname = module_detail.fullname
         automatic_exploitation_match.save!
@@ -17,7 +17,21 @@ RSpec.describe MetasploitDataModels::AutomaticExploitation::Match, type: :model 
       it 'should point to the Mdm::Module::Detail with a fullname corresponding to #module_fullname' do
         expect(automatic_exploitation_match.module_detail).to eq(module_detail)
       end
-
     end
+
+    describe "deleting the associated Mdm::Module::Detail" do
+      subject(:automatic_exploitation_match){ FactoryGirl.create(:automatic_exploitation_match) }
+      let(:match_id){ automatic_exploitation_match.id }
+
+      before(:each) do
+        automatic_exploitation_match.module_detail.destroy
+      end
+
+      it 'should still exist in the DB' do
+        the_match = MetasploitDataModels::AutomaticExploitation::Match.find(match_id)
+        expect(the_match).to_not be_blank
+      end
+    end
+
   end
 end

--- a/spec/factories/metasploit_data_models/automatic_exploitation/matches.rb
+++ b/spec/factories/metasploit_data_models/automatic_exploitation/matches.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :automatic_exploitation_match, :class => MetasploitDataModels::AutomaticExploitation::Match do
     association :module_detail, factory: :mdm_module_detail
     association :match_set, factory: :automatic_exploitation_match_set
+    association :matchable, factory: :mdm_vuln
   end
 end


### PR DESCRIPTION
MSP-12813

## Verification
- [x] `rake spec`
- [x] VERIFY: all tests pass
- [x] merge to master on CLI
- [x] open `lib/metasploit_data_models/version.rb` and remove `PRERELEASE` line and comment
- [x] `rake spec`
- [x] VERIFY: all tests pass
- [x] Commit and push to master
- [ ] `rake release`