### PR TITLE
Fix broken Recog service matching in MDM

### DIFF
--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -204,8 +204,7 @@ module Mdm::Host::OperatingSystemNormalization
     # Mdm currently serves that role.
     #
 
-    service_match_keys = Hash.new { [] }
-    service_match_keys.merge({
+    service_match_keys = {
       # TODO: Implement smb.generic fingerprint database
       # 'smb'     => [ 'smb.generic' ], # Distinct from smb.fingerprint, use os.certainty to choose best match
       # 'netbios' => [ 'smb.generic' ], # Distinct from smb.fingerprint, use os.certainty to choose best match
@@ -221,7 +220,7 @@ module Mdm::Host::OperatingSystemNormalization
       'nntp'    => [ 'nntp.banner' ],
       'ftp'     => [ 'ftp.banner' ],
       'ssdp'    => [ 'ssdp_header.server' ]
-    })
+    }
 
     matches = []
 

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -231,7 +231,7 @@ module Mdm::Host::OperatingSystemNormalization
       end
       res = Recog::Nizer.match(rdb, banner)
       matches << res if res
-    end
+    end if service_match_keys.has_key?(s.name)
 
     matches
   end


### PR DESCRIPTION
In working on https://github.com/rapid7/metasploit-framework/pull/5563, I discovered that the recog service fingerprint matching seems to have been broken since 4b320a85df30bef36b58a9dd354ec6cfc32ed53e. 

I'm going to see about the possibility of adding a unit test here.

Relevant to https://github.com/rapid7/metasploit-framework/pull/5563