### PR TITLE
Properly match Recog service information

### DIFF
--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -204,8 +204,7 @@ module Mdm::Host::OperatingSystemNormalization
     # Mdm currently serves that role.
     #
 
-    service_match_keys = Hash.new { [] }
-    service_match_keys.merge({
+    service_match_keys = {
       # TODO: Implement smb.generic fingerprint database
       # 'smb'     => [ 'smb.generic' ], # Distinct from smb.fingerprint, use os.certainty to choose best match
       # 'netbios' => [ 'smb.generic' ], # Distinct from smb.fingerprint, use os.certainty to choose best match
@@ -221,7 +220,7 @@ module Mdm::Host::OperatingSystemNormalization
       'nntp'    => [ 'nntp.banner' ],
       'ftp'     => [ 'ftp.banner' ],
       'ssdp'    => [ 'ssdp_header.server' ]
-    })
+    }
 
     matches = []
 

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -231,7 +231,7 @@ module Mdm::Host::OperatingSystemNormalization
       end
       res = Recog::Nizer.match(rdb, banner)
       matches << res if res
-    end
+    end if service_match_keys.has_key?(s.name)
 
     matches
   end

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -224,6 +224,8 @@ module Mdm::Host::OperatingSystemNormalization
 
     matches = []
 
+    return matches unless service_match_keys.has_key?(s.name)
+
     service_match_keys[s.name].each do |rdb|
       banner = s.info
       if self.respond_to?("service_banner_recog_filter_#{s.name}")
@@ -231,7 +233,7 @@ module Mdm::Host::OperatingSystemNormalization
       end
       res = Recog::Nizer.match(rdb, banner)
       matches << res if res
-    end if service_match_keys.has_key?(s.name)
+    end
 
     matches
   end

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -11,6 +11,8 @@ module MetasploitDataModels
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 4
+    # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version number.
+    PRERELEASE = 'recog-service-never-match'
 
 
     #

--- a/spec/app/models/mdm/host_spec.rb
+++ b/spec/app/models/mdm/host_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe Mdm::Host, type: :model do
+  include_context 'Rex::Text'
+
   subject(:host) do
     FactoryGirl.build(:mdm_host)
   end
@@ -724,19 +726,6 @@ RSpec.describe Mdm::Host, type: :model do
 
 
     context '#apply_match_to_host' do
-
-      before(:each) do
-        stub_const(
-            'Rex::Text',
-            Module.new do
-              def self.ascii_safe_hex(unsanitized)
-                # Pass back the sanitized value for the stub
-                unsanitized.unpack("C*").pack("C*").gsub(/([\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xFF])/n){ |x| "\\x%.2x" % x.unpack("C*")[0]}
-              end
-            end
-        )
-      end
-
       it 'should set host.mac when host.mac is present' do
         match = { 'host.mac' => '00:11:22:33:44:55' }
         host.send(:apply_match_to_host, match)

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -1,6 +1,3 @@
-#puts $LOAD_PATH
-#require 'support/shared/contexts/rex/text'
-
 RSpec.describe Mdm::Service, type: :model do
   it_should_behave_like 'Metasploit::Concern.run'
   include_context 'Rex::Text'

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe Mdm::Service, type: :model do
         expect(svc).to receive(:normalize_host_os)
         svc.run_callbacks(:save)
       end
+
       it 'should include recog data when there is a match' do
         host = FactoryGirl.create(:mdm_host)
         FactoryGirl.create(
@@ -83,6 +84,7 @@ RSpec.describe Mdm::Service, type: :model do
         expect(host.name).to eq('example.com')
         expect(host.os_name).to eq('Windows NT')
       end
+
       it 'should not include recog data when there is not a match' do
         host = FactoryGirl.create(:mdm_host)
         FactoryGirl.create(

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe Mdm::Service, type: :model do
   it_should_behave_like 'Metasploit::Concern.run'
-  include_context 'Rex::Text'
 
   context 'CONSTANTS' do
     context 'PROTOS' do
@@ -67,6 +66,8 @@ RSpec.describe Mdm::Service, type: :model do
 
   context 'callbacks' do
     context 'after_save' do
+      include_context 'Rex::Text'
+
       it 'should call #normalize_host_os' do
         svc = FactoryGirl.create(:mdm_service)
         expect(svc).to receive(:normalize_host_os)

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -1,5 +1,9 @@
+#puts $LOAD_PATH
+#require 'support/shared/contexts/rex/text'
+
 RSpec.describe Mdm::Service, type: :model do
   it_should_behave_like 'Metasploit::Concern.run'
+  include_context 'Rex::Text'
 
   context 'CONSTANTS' do
     context 'PROTOS' do
@@ -70,6 +74,27 @@ RSpec.describe Mdm::Service, type: :model do
         svc = FactoryGirl.create(:mdm_service)
         expect(svc).to receive(:normalize_host_os)
         svc.run_callbacks(:save)
+      end
+      it 'should include recog data when there is a match' do
+        host = FactoryGirl.create(:mdm_host)
+        FactoryGirl.create(
+          :mdm_service,
+          :host => host,
+          :name => 'ftp',
+          :info => 'example.com Microsoft FTP Service (Version 3.0).'
+        )
+        expect(host.name).to eq('example.com')
+        expect(host.os_name).to eq('Windows NT')
+      end
+      it 'should not include recog data when there is not a match' do
+        host = FactoryGirl.create(:mdm_host)
+        FactoryGirl.create(
+          :mdm_service,
+          :host => host,
+          :name => 'ftp',
+          :info => 'THISSHOULDNEVERMATCH'
+        )
+        expect(host.os_name).to eq('Unknown')
       end
     end
   end


### PR DESCRIPTION
Fixes #132.

Due to an improper use of Hash.merge in https://github.com/rapid7/metasploit_data_models/blob/10fce8e90f20688ef78de054d54c4031425662a4/lib/mdm/host/operating_system_normalization.rb#L207-228, no fingerprints that would normally be matched and returned from recog will ever be returned.  

It is understood that all of this is a little kludgy right now and is probably a good candidate for refactoring, especially given the intent in https://github.com/rapid7/metasploit-framework/pull/5563, but for now I'm looking to simply get this functionality fixed and we can ponder a larger refactor later.

# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] VERIFY no failures

## `rake yard`
- [ ] `rake yard`
- [ ] VERIFY no `[warn]`ings
- [ ] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`