### PR TITLE
Bug/msp 12834/crawler choke on save

### DIFF
--- a/app/models/mdm/web_page.rb
+++ b/app/models/mdm/web_page.rb
@@ -83,6 +83,9 @@ class Mdm::WebPage < ActiveRecord::Base
   # @return [Hash{String => String}]
   serialize :headers, MetasploitDataModels::Base64Serializer.new
 
+  # Cookies sent from server.
+  #
+  # @return [Hash{String => String}]
   serialize :cookie
   Metasploit::Concern.run(self)
 end

--- a/app/models/mdm/web_page.rb
+++ b/app/models/mdm/web_page.rb
@@ -46,7 +46,7 @@ class Mdm::WebPage < ActiveRecord::Base
 
   # @!attribute location
   #   Location derived from {#headers}.
-  #
+
   #   @return [String]
 
   # @!attribute mtime
@@ -82,7 +82,8 @@ class Mdm::WebPage < ActiveRecord::Base
   #
   # @return [Hash{String => String}]
   serialize :headers, MetasploitDataModels::Base64Serializer.new
-    
+
+  serialize :cookie
   Metasploit::Concern.run(self)
 end
 

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 4
+    PATCH = 5
+    # Remove on master
+    PRERELEASE = 'crawler-choke-on-save'
 
 
     #


### PR DESCRIPTION
MSP-12834
rapid7/metasploit-framework#5515

- [x] Verify all specs pass: `rake spec`
- [x] Verify 100% docs coverage: `rake yard`
- [x] Merge to master
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.
- [x] `rake spec`
- [x] VERIFY version examples pass without failures
- [x] `git commit -a`
- [x] `git push origin master`
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`