### PR TITLE
Bug/msp 13193/zip export web scan

### DIFF
--- a/app/models/mdm/web_page.rb
+++ b/app/models/mdm/web_page.rb
@@ -86,7 +86,7 @@ class Mdm::WebPage < ActiveRecord::Base
   # Cookies sent from server.
   #
   # @return [Hash{String => String}]
-  serialize :cookie
+  serialize :cookie, MetasploitDataModels::Base64Serializer.new
   Metasploit::Concern.run(self)
 end
 

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,7 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 7
+    PATCH = 8
     # Remove on master
     PRERELEASE = 'zip-export-web-scan'
 

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 6
+    PATCH = 7
+    # Remove on master
+    PRERELEASE = 'zip-export-web-scan'
 
 
     #

--- a/spec/app/models/mdm/web_page_spec.rb
+++ b/spec/app/models/mdm/web_page_spec.rb
@@ -3,6 +3,48 @@ RSpec.describe Mdm::WebPage, type: :model do
 
   context 'associations' do
     it { is_expected.to belong_to(:web_site).class_name('Mdm::WebSite') }
+
+    context 'serialized cookie attribute' do
+      let(:valid_cookie) do
+        {
+          name: 'test name',
+          value: 'test value'
+        }
+      end
+
+      let(:invalid_cookie) do
+        """
+          --- !ruby/object:WEBrick::Cookie
+          name: 'test name'
+          value: 'test value'
+        """
+      end
+
+      let(:cookie) { valid_cookie }
+      let(:web_page) { FactoryGirl.create(:mdm_web_page, cookie: cookie) }
+
+      context 'with properly formed cookie' do
+        let(:cookie) { valid_cookie }
+        it 'persists successfully' do
+          expect{web_page}.to change{Mdm::WebPage.count}.by(1)
+        end
+
+        it 'reading cookie returns a hash' do
+          expect(web_page.cookie).to be_a Hash
+        end
+      end
+
+      context 'with malformed cookie' do
+        let(:cookie) { invalid_cookie }
+        it 'persists successfully' do
+          expect{web_page}.to change{Mdm::WebPage.count}.by(1)
+        end
+
+        it 'reading cookie returns as string' do
+          expect(web_page.cookie).to be_a String
+        end
+      end
+    end
   end
 
   context 'database' do


### PR DESCRIPTION
PR uses the custom serializer for Mdm::WebPage cookie attribute so that even with malformed cookies it gracefully persists and reads. It fixes an issue in encountered in Pro.

MSP-13193

# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] **Verify** `Warning from shoulda-matchers` is NOT printed.
- [ ] **Verify** no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## Version

### Compatible changes

- Incremented [`PATCH`](lib/metasploit_data_models/version.rb). (Should be 1.2.8)

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`