### PR TITLE
remove exclusion of localhost address 127.0.0.1

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -463,9 +463,6 @@ class Mdm::Host < ActiveRecord::Base
   #
 
   validates :address,
-            :exclusion => {
-                :in => [IPAddr.new('127.0.0.1')]
-            },
             :ip_format => true,
             :presence => true,
             :uniqueness => {

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -11,7 +11,7 @@ module MetasploitDataModels
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 10
-    PRERELEASE = "allow_localhost"
+    PRERELEASE = "allow-localhost"
 
     #
     # Module Methods

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,8 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 9
+    PATCH = 10
+    PRERELEASE = "allow_localhost"
 
     #
     # Module Methods

--- a/spec/app/models/mdm/host_spec.rb
+++ b/spec/app/models/mdm/host_spec.rb
@@ -383,7 +383,6 @@ RSpec.describe Mdm::Host, type: :model do
 
   context 'validations' do
     context 'address' do
-      it { is_expected.to validate_exclusion_of(:address).in_array(['127.0.0.1']) }
       it { is_expected.to validate_presence_of(:address) }
 
       # can't use validate_uniqueness_of(:address).scoped_to(:workspace_id) because it will attempt to set workspace_id


### PR DESCRIPTION
Often, it is convenient to allow localhost to be a valid host IP; for instance when testing, or when using a proxy or tunnel configuration. Our current localhost exclusion does not actually prevent all local IPs from being included as a host element anyway (e.g. ipv6 is not excluded, all of the other 127.0.0/8 addresses, etc.) so the current exclusion of 127.0.0.1 does not provide a lot of value, at least from metasploit-framework's point-of-view.

# Release

Complete these steps on DESTINATION

## [CHANGELOG.md](CHANGELOG.md)

### Terminology

* "Enhancements" are widdening the API, such as by adding new classes or methods.
* "Bug Fixes" are fixes to the implementation that do not affect the public API.  If the public API is affected then
  the change should be listed as both a "Bug Fix" and either an "Enhancement" or "Incompatible Change" depending on how
  the bug was fixed.
* "Deprecations" are changes to the implementation that cause deprecation warnings to be issued for APIs which will be
  removed in a future major release.  "Deprecations" are usually accompanied by an Enhancement that creates a new API
  that is meant to be used in favor of the deprecated API.
* "Incompatbile Changes" are the removal of classes or methods or new required arguments or setup that shrink the API.
  It is best practice to make a "Deprecation" for the API prior to its removal.

### Task List

- [ ] Generate the list of changes since the last release: `git log v<LAST_MAJOR>.<LAST_MINOR>.<LAST_PATCH>..HEAD`
- [ ] For each commit in the release, find the corresponding PR by search for the commit on Github.
- [ ] For each PR, determine whether it is an Enhancement, Bug Fix, Deprecation, and/or Incompatible Change.  A PR can
      be in more than one category, in which case it should be listed in each category it belongs, but with a category
      specific description of the change.
- [ ] Add an item to each category's list in the following format: `[#<PR>](https://github.com/rapid7/metasploit_data_models/pull/<PR>) <consumer summary> - [@<github_user>](https://github.com/<github_user>)`
      `consumer_summary` should be a summary of the Enhancement, Bug Fix, Deprecation, or Incompatible Change from a
      downstream consumer's of the library's perspective.  `github_user` should be Github handle of the author of the
      PR.
- [ ] If you added any Deprecations or Incompatible Changes, then adding upgrading information to
      [UPGRADING.md](UPGRADING.md)

## `VERSION`

The entries in the [CHANGELOG.md](CHANGELOG.md) can be used to help determine how the `VERSION` should be bumped.

### Bug fixes

If the [CHANGELOG.md](CHANGELOG.md) contains only Bug Fixes for the Next Release, then increment
[`PATCH`](lib/metasploit_data_models/version.rb).

### Compatible API changes

If the [CHANGELOG.md](CHANGELOG.md) contains any Enhancements or Deprecations, then increment
[`MINOR`](lib/metasploit_data_models/version.rb) and reset [`PATCH`](lib/metasploit_data_models/version.rb) to `0`.

### Incompatible API changes

If the [CHANGELOG.md](CHANGELOG.md) contains any Incompatible Change, then increment [`MAJOR`](lib/metasploit_data_models/version.rb) and
reset [`MINOR`](lib/metasploit_data_models/version.rb and [`PATCH`](lib/metasploit_data_models/version.rb) to `0`.

## Setup [CHANGELOG.md](CHANGELOG.md) for next release

- [ ] Change `Next Release` section name at the top of [CHANGELOG.md](CHANGELOG.md) to match the current `VERSION`.
- [ ] Add a new `Next Release` section above the `VERSION`'s section you just renamed:

## Release to rubygems.org

## ruby-2.1
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`