### PR TITLE
Cookie attribute can support WEBrick::Cookie objects on serialization

### DIFF
--- a/app/models/mdm/web_page.rb
+++ b/app/models/mdm/web_page.rb
@@ -1,4 +1,5 @@
 # Web page requested from a {#web_site}.
+require 'webrick'
 class Mdm::WebPage < ActiveRecord::Base
   
   #

--- a/app/models/mdm/web_page.rb
+++ b/app/models/mdm/web_page.rb
@@ -1,5 +1,4 @@
 # Web page requested from a {#web_site}.
-require 'webrick'
 class Mdm::WebPage < ActiveRecord::Base
   
   #

--- a/lib/metasploit_data_models.rb
+++ b/lib/metasploit_data_models.rb
@@ -2,6 +2,8 @@
 # Core
 #
 require 'shellwords'
+# So that Mdm::WebPage#cookie can support serializing a WEBrick::Cookie
+require 'webrick'
 
 #
 # Gems

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 10
+    PATCH = 11
+    # Remove on master
+    PRERELEASE = 'zip-export-web-scan-cookies'
 
     #
     # Module Methods

--- a/spec/app/models/mdm/web_page_spec.rb
+++ b/spec/app/models/mdm/web_page_spec.rb
@@ -1,4 +1,3 @@
-require 'webrick'
 RSpec.describe Mdm::WebPage, type: :model do
   it_should_behave_like 'Metasploit::Concern.run'
 

--- a/spec/app/models/mdm/web_page_spec.rb
+++ b/spec/app/models/mdm/web_page_spec.rb
@@ -4,16 +4,18 @@ RSpec.describe Mdm::WebPage, type: :model do
 
   context 'associations' do
     it { is_expected.to belong_to(:web_site).class_name('Mdm::WebSite') }
+  end
 
-    context 'serialized cookie attribute' do
+  context 'serialized attributes' do
+    context 'cookie' do
       let(:string_cookie) do
         "test_name=test_value"
       end
 
       let(:hash_cookie) do
         {
-          name: 'test name',
-          value: 'test value'
+            name: 'test name',
+            value: 'test value'
         }
       end
 

--- a/spec/app/models/mdm/web_page_spec.rb
+++ b/spec/app/models/mdm/web_page_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Mdm::WebPage, type: :model do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)
         end
 
-        it 'reading cookie returns a hash' do
+        it 'reading cookie returns a string' do
           expect(web_page.cookie).to be_a String
         end
       end
@@ -51,7 +51,7 @@ RSpec.describe Mdm::WebPage, type: :model do
 
       context 'with WEBrick::Cookie' do
         let(:cookie) { webrick_cookie }
-        
+
         it 'persists successfully' do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)
         end

--- a/spec/app/models/mdm/web_page_spec.rb
+++ b/spec/app/models/mdm/web_page_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Mdm::WebPage, type: :model do
 
       context 'with string cookie' do
         let(:cookie) { string_cookie }
+
         it 'persists successfully' do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)
         end
@@ -38,6 +39,7 @@ RSpec.describe Mdm::WebPage, type: :model do
 
       context 'with Hash cookie' do
         let(:cookie) { hash_cookie }
+
         it 'persists successfully' do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)
         end
@@ -49,6 +51,7 @@ RSpec.describe Mdm::WebPage, type: :model do
 
       context 'with WEBrick::Cookie' do
         let(:cookie) { webrick_cookie }
+        
         it 'persists successfully' do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)
         end

--- a/spec/app/models/mdm/web_page_spec.rb
+++ b/spec/app/models/mdm/web_page_spec.rb
@@ -1,8 +1,61 @@
+require 'webrick'
 RSpec.describe Mdm::WebPage, type: :model do
   it_should_behave_like 'Metasploit::Concern.run'
 
   context 'associations' do
     it { is_expected.to belong_to(:web_site).class_name('Mdm::WebSite') }
+
+    context 'serialized cookie attribute' do
+      let(:string_cookie) do
+        "test_name=test_value"
+      end
+
+      let(:hash_cookie) do
+        {
+          name: 'test name',
+          value: 'test value'
+        }
+      end
+
+      let(:webrick_cookie) do
+        WEBrick::Cookie.new('test name', 'test value')
+      end
+
+      let(:web_page) { FactoryGirl.create(:mdm_web_page, cookie: cookie) }
+
+      context 'with string cookie' do
+        let(:cookie) { string_cookie }
+        it 'persists successfully' do
+          expect{web_page}.to change{Mdm::WebPage.count}.by(1)
+        end
+
+        it 'reading cookie returns a hash' do
+          expect(web_page.cookie).to be_a String
+        end
+      end
+
+      context 'with Hash cookie' do
+        let(:cookie) { hash_cookie }
+        it 'persists successfully' do
+          expect{web_page}.to change{Mdm::WebPage.count}.by(1)
+        end
+
+        it 'reading cookie returns a hash' do
+          expect(web_page.cookie).to be_a Hash
+        end
+      end
+
+      context 'with WEBrick::Cookie' do
+        let(:cookie) { webrick_cookie }
+        it 'persists successfully' do
+          expect{web_page}.to change{Mdm::WebPage.count}.by(1)
+        end
+
+        it 'reading cookie returns as WEBrick::Cookie object' do
+          expect(web_page.cookie).to be_a WEBrick::Cookie
+        end
+      end
+    end
   end
 
   context 'database' do

--- a/spec/app/models/mdm/web_page_spec.rb
+++ b/spec/app/models/mdm/web_page_spec.rb
@@ -7,25 +7,10 @@ RSpec.describe Mdm::WebPage, type: :model do
 
   context 'serialized attributes' do
     context 'cookie' do
-      let(:string_cookie) do
-        "test_name=test_value"
-      end
-
-      let(:hash_cookie) do
-        {
-            name: 'test name',
-            value: 'test value'
-        }
-      end
-
-      let(:webrick_cookie) do
-        WEBrick::Cookie.new('test name', 'test value')
-      end
-
       let(:web_page) { FactoryGirl.create(:mdm_web_page, cookie: cookie) }
 
       context 'with string cookie' do
-        let(:cookie) { string_cookie }
+        let(:cookie) { "test_name=test_value" }
 
         it 'persists successfully' do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)
@@ -37,7 +22,12 @@ RSpec.describe Mdm::WebPage, type: :model do
       end
 
       context 'with Hash cookie' do
-        let(:cookie) { hash_cookie }
+        let(:cookie) do
+          {
+            name: 'test name',
+            value: 'test value'
+          }
+        end
 
         it 'persists successfully' do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)
@@ -49,7 +39,7 @@ RSpec.describe Mdm::WebPage, type: :model do
       end
 
       context 'with WEBrick::Cookie' do
-        let(:cookie) { webrick_cookie }
+        let(:cookie) { WEBrick::Cookie.new('test name', 'test value') }
 
         it 'persists successfully' do
           expect{web_page}.to change{Mdm::WebPage.count}.by(1)


### PR DESCRIPTION
Adds WEBrick standard library to Mdm::WebPage so that cookie attribute can support WEBrick::Cookie objects on serialization. It fixes an issue in encountered in Pro.

MSP-13193

# Changelog
* Enhancements
  * `Mdm::WebPage#cookie` can support `WEBrick::Cookie` objects on serialization

# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] **Verify** `Warning from shoulda-matchers` is NOT printed.
- [ ] **Verify** no failures

## Manually test creating Mdm::WebPage with WEBrick::Cookie
- [ ] `$ cd spec/dummy & rails c`
- [ ] In rails console:
```
cookie = WEBrick::Cookie.new('test name', 'test value')
wp = Mdm::WebPage.create(cookie: cookie, web_site_id: 1, code: 'doge')
wp.cookie
```
- [ ] Verify web page gets persisted and cookie attribute succesfully loads without error

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## Version

### Compatible changes

- Incremented [`PATCH`](lib/metasploit_data_models/version.rb). (Should be 1.2.8)

## JRuby
- [ ] `rvm use jruby@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`