### PR TITLE
Add search on vulns tables by host name column

### DIFF
--- a/app/models/mdm/vuln.rb
+++ b/app/models/mdm/vuln.rb
@@ -176,6 +176,8 @@ class Mdm::Vuln < ActiveRecord::Base
         Mdm::Ref.arel_table[:name].matches(formatted_query)
       ).or(
         Arel::Nodes::NamedFunction.new('CAST', [Mdm::Host.arel_table[:address].as('TEXT')]).matches(formatted_query)
+      ).or(
+        Mdm::Host.arel_table[:name].matches(formatted_query)
       )
     ).includes(
       :refs, :host

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -10,7 +10,9 @@ module MetasploitDataModels
     # The minor version number, scoped to the {MAJOR} version number.
     MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 8
+    PATCH = 9
+    # Remove on master
+    PRERELEASE = 'search-host-name-vulns'
 
     #
     # Module Methods

--- a/spec/app/models/mdm/vuln_spec.rb
+++ b/spec/app/models/mdm/vuln_spec.rb
@@ -266,6 +266,15 @@ RSpec.describe Mdm::Vuln, type: :model do
               expect(results).to match_array [vuln_with_host]
             end
           end
+
+          context 'with query matching Mdm::Host name' do
+            let(:vuln_with_host) { FactoryGirl.create(:mdm_vuln, :host)}
+            let(:query) { vuln_with_host.host.name}
+
+            it 'should match Mdm::Vuln' do
+              expect(results).to match_array [vuln_with_host]
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
MS-120

* host name search scope added to vulns

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no `[warn]`ings
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [ ] `git push origin master`
- [ ] push gem to RubyGems