### PR TITLE
fix uniq scope on host

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -301,11 +301,11 @@ class Mdm::Host < ActiveRecord::Base
   #   {Mdm::Module::Detail Details about modules} that were used to find {#vulns vulnerabilities} on this host.
   #
   #   @return [ActiveRecord::Relation<Mdm::Module::Detail]
-  has_many :module_details,
+  has_many :module_details, -> { uniq } ,
            :class_name => 'Mdm::Module::Detail',
            :source =>:detail,
-           :through => :module_refs,
-           :uniq => true
+           :through => :module_refs
+
 
   #
   # Attributes

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,12 +6,13 @@ module MetasploitDataModels
     #
 
     # The major version number.
-    MAJOR = 1
+    MAJOR = 2
     # The minor version number, scoped to the {MAJOR} version number.
-    MINOR = 2
+    MINOR = 0
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 10
+    PATCH = 0
 
+    PRERELEASE = 'uniq-deprecation'
     #
     # Module Methods
     #

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -12,7 +12,7 @@ module MetasploitDataModels
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 0
 
-    PRERELEASE = 'uniq-deprecation'
+    PRERELEASE = 'rails-4-deprecations'
     #
     # Module Methods
     #


### PR DESCRIPTION
Use an actual scope to uniq the relation for module details, instead of uniq: true

MS-1082

VERIFICATION STEPS
- [x] run `rake spec`
- [x] VERIFY all specs pass
- [x] VERIFY you no longer see any deprecation warnings about `deprecated: :uniq. Please use a scope block instead`
- [x] Change prerelease tag to `rails-4-deprecations`
- [x] merge