### PR TITLE
Feature/ms 1084/transpec conversions

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,11 +6,13 @@ module MetasploitDataModels
     #
 
     # The major version number.
-    MAJOR = 1
+    MAJOR = 2
     # The minor version number, scoped to the {MAJOR} version number.
-    MINOR = 2
+    MINOR = 0
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 10
+    PATCH = 0
+
+    PRERELEASE = 'transpec-conversions'
 
     #
     # Module Methods

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -6,11 +6,11 @@ module MetasploitDataModels
     #
 
     # The major version number.
-    MAJOR = 2
+    MAJOR = 1
     # The minor version number, scoped to the {MAJOR} version number.
-    MINOR = 0
+    MINOR = 2
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-    PATCH = 0
+    PATCH = 11
 
     PRERELEASE = 'transpec-conversions'
 

--- a/spec/app/models/mdm/cred_spec.rb
+++ b/spec/app/models/mdm/cred_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe Mdm::Cred, type: :model do
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         ssh_key
         ssh_pubkey
       end
@@ -287,7 +287,7 @@ RSpec.describe Mdm::Cred, type: :model do
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         ssh_key
         ssh_pubkey
       end
@@ -321,7 +321,7 @@ RSpec.describe Mdm::Cred, type: :model do
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         ssh_key
         ssh_pubkey
       end

--- a/spec/app/models/mdm/event_spec.rb
+++ b/spec/app/models/mdm/event_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Mdm::Event, type: :model do
       let(:flagged_event) { FactoryGirl.create(:mdm_event, :workspace => workspace, :name => 'flagme', :critical => true, :seen => false) }
       let(:non_critical_event) { FactoryGirl.create(:mdm_event, :workspace => workspace, :name => 'dontflagmebro', :critical => false, :seen => false) }
 
-      before(:each) do
+      before(:example) do
         flagged_event
         non_critical_event
       end

--- a/spec/app/models/mdm/module/detail_spec.rb
+++ b/spec/app/models/mdm/module/detail_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Mdm::Module::Detail, type: :model do
     # validate_inclusion_of(:privileged).in_array([true, false]) will fail on the disallowed values check.
 
     context 'rank' do
-      it 'validates rank is only an integer', pending: 'https://github.com/thoughtbot/shoulda-matchers/issues/784' do
+      it 'validates rank is only an integer' do
         is_expected.to validate_numericality_of(:rank).only_integer
       end
 

--- a/spec/app/models/mdm/module/detail_spec.rb
+++ b/spec/app/models/mdm/module/detail_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Mdm::Module::Detail, type: :model do
   end
 
   context 'with saved' do
-    before(:each) do
+    before(:example) do
       detail.save!
     end
 

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Mdm::Service, type: :model do
       FactoryGirl.build(:mdm_service)
     }
 
-    it 'validate port is only an integer', pending: 'https://github.com/thoughtbot/shoulda-matchers/issues/784' do
+    it 'validate port is only an integer' do
       is_expected.to validate_numericality_of(:port).only_integer
     end
 

--- a/spec/app/models/mdm/web_vuln_spec.rb
+++ b/spec/app/models/mdm/web_vuln_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Mdm::WebVuln, type: :model do
       it { is_expected.to be_valid }
 
       context 'after reloading' do
-        before(:each) do
+        before(:example) do
           mdm_web_vuln.save!
           mdm_web_vuln.reload
         end
@@ -142,7 +142,7 @@ RSpec.describe Mdm::WebVuln, type: :model do
             web_vuln.params.index(element)
           end
 
-          before(:each) do
+          before(:example) do
             web_vuln.params = [element]
           end
 

--- a/spec/app/models/mdm/workspace_spec.rb
+++ b/spec/app/models/mdm/workspace_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Mdm::Workspace, type: :model do
         'must be a valid IP range'
       end
 
-      before(:each) do
+      before(:example) do
         workspace.boundary = boundary
         workspace.valid?
       end
@@ -234,7 +234,7 @@ RSpec.describe Mdm::Workspace, type: :model do
 
     context 'default' do
       context 'with default workspace' do
-        before(:each) do
+        before(:example) do
           FactoryGirl.create(
               :mdm_workspace,
               :name => default
@@ -271,7 +271,7 @@ RSpec.describe Mdm::Workspace, type: :model do
       end
 
       context 'with DEFAULT name' do
-        before(:each) do
+        before(:example) do
           workspace.name = default
         end
 
@@ -378,7 +378,7 @@ RSpec.describe Mdm::Workspace, type: :model do
         workspace.send(:normalize)
       end
 
-      before(:each) do
+      before(:example) do
         workspace.boundary = boundary
       end
 
@@ -459,7 +459,7 @@ RSpec.describe Mdm::Workspace, type: :model do
       # Let!s (let + before(:each))
       #
 
-      before(:each) do
+      before(:example) do
         other_web_sites
         web_sites
       end

--- a/spec/app/models/mdm/workspace_spec.rb
+++ b/spec/app/models/mdm/workspace_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Mdm::Workspace, type: :model do
       end
 
       it 'should be an ActiveRecord::Relation', :pending => 'https://www.pivotaltracker.com/story/show/43219917' do
-        should be_a ActiveRecord::Relation
+        is_expected.to be_a ActiveRecord::Relation
       end
 
       it 'should include services' do
@@ -357,7 +357,7 @@ RSpec.describe Mdm::Workspace, type: :model do
       end
 
       it 'should return an ActiveRecord::Relation', :pending => 'https://www.pivotaltracker.com/story/show/43219917' do
-        should be_a ActiveRecord::Relation
+        is_expected.to be_a ActiveRecord::Relation
       end
 
       it 'should return only Mdm::Tags from hosts in the workspace' do
@@ -434,7 +434,7 @@ RSpec.describe Mdm::Workspace, type: :model do
       end
 
       it 'should return an ActiveRecord:Relation' do
-        should be_a ActiveRecord::Relation
+        is_expected.to be_a ActiveRecord::Relation
       end
 
       it 'should return only Mdm::WebPages from hosts in the workspace' do
@@ -465,7 +465,7 @@ RSpec.describe Mdm::Workspace, type: :model do
       end
 
       it 'should return an ActiveRecord:Relation' do
-        should be_a ActiveRecord::Relation
+        is_expected.to be_a ActiveRecord::Relation
       end
 
       it 'should return only Mdm::WebVulns from hosts in the workspace' do
@@ -506,7 +506,7 @@ RSpec.describe Mdm::Workspace, type: :model do
       end
 
       it 'should return an ActiveRecord:Relation' do
-        should be_a ActiveRecord::Relation
+        is_expected.to be_a ActiveRecord::Relation
       end
 
       it 'should return only Mdm::WebVulns from hosts in the workspace' do
@@ -535,7 +535,7 @@ RSpec.describe Mdm::Workspace, type: :model do
 
       it 'should return an ActiveRecord:Relation',
          :pending => 'https://www.pivotaltracker.com/story/show/43219917' do
-        should be_a ActiveRecord::Relation
+        is_expected.to be_a ActiveRecord::Relation
       end
 
       it "should reject #unique_web_forms from host addresses that aren't in addresses" do

--- a/spec/app/models/metasploit_data_models/automatic_exploitation/match_set_spec.rb
+++ b/spec/app/models/metasploit_data_models/automatic_exploitation/match_set_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe MetasploitDataModels::AutomaticExploitation::MatchSet, type: :mod
     subject(:match_set){ FactoryGirl.build(:automatic_exploitation_match_set)}
 
     describe "missing user" do
-      before(:each) do
+      before(:example) do
         match_set.user = nil
       end
 
@@ -34,7 +34,7 @@ RSpec.describe MetasploitDataModels::AutomaticExploitation::MatchSet, type: :mod
     end
 
     describe "missing workspace" do
-      before(:each) do
+      before(:example) do
         match_set.workspace = nil
       end
 

--- a/spec/app/models/metasploit_data_models/automatic_exploitation/match_spec.rb
+++ b/spec/app/models/metasploit_data_models/automatic_exploitation/match_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MetasploitDataModels::AutomaticExploitation::Match, type: :model 
 
       subject(:automatic_exploitation_match){ described_class.new }
 
-      before(:each) do
+      before(:example) do
         automatic_exploitation_match.matchable = vuln
         automatic_exploitation_match.module_fullname = module_detail.fullname
         automatic_exploitation_match.save!
@@ -23,7 +23,7 @@ RSpec.describe MetasploitDataModels::AutomaticExploitation::Match, type: :model 
       subject(:automatic_exploitation_match){ FactoryGirl.create(:automatic_exploitation_match) }
       let(:match_id){ automatic_exploitation_match.id }
 
-      before(:each) do
+      before(:example) do
         automatic_exploitation_match.module_detail.destroy
       end
 

--- a/spec/app/models/metasploit_data_models/automatic_exploitation/run_spec.rb
+++ b/spec/app/models/metasploit_data_models/automatic_exploitation/run_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe MetasploitDataModels::AutomaticExploitation::Run, type: :model do
 
   describe "destroying" do
     describe "associated MatchResults" do
-      before(:each) do
+      before(:example) do
         match_set = FactoryGirl.create(:automatic_exploitation_match_set)
         match = FactoryGirl.create(:automatic_exploitation_match, match_set: match_set)
         run.match_set = match_set

--- a/spec/app/models/metasploit_data_models/ip_address/v4/cidr_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/cidr_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::CIDR, type: :model do
       it { is_expected.not_to be_valid }
 
       context 'errors' do
-        before(:each) do
+        before(:example) do
           cidr.valid?
         end
 
@@ -86,7 +86,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::CIDR, type: :model do
       it { is_expected.not_to be_valid }
 
       context 'errors' do
-        before(:each) do
+        before(:example) do
           cidr.valid?
         end
 

--- a/spec/app/models/metasploit_data_models/ip_address/v4/nmap_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/nmap_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Nmap, type: :model do
   }
 
   context 'validation' do
-    before(:each) do
+    before(:example) do
       nmap.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/ip_address/v4/range_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/range_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Range, type: :model do
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       range.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/ip_address/v4/segment/nmap/list_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/segment/nmap/list_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Segment::Nmap::List, type: :
   end
 
   context 'validation' do
-    before(:each) do
+    before(:example) do
       nmap.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/ip_address/v4/segment/nmap/range_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/segment/nmap/range_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Segment::Nmap::Range, type: 
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       range.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/ip_address/v4/segment/single_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/segment/single_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Segment::Single, type: :mode
   }
 
   context 'validations' do
-    it 'validates value is only an integer between 0 and 255 inclusive', pending: 'https://github.com/thoughtbot/shoulda-matchers/issues/784' do
+    it 'validates value is only an integer between 0 and 255 inclusive' do
       is_expected.to validate_numericality_of(:value).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(255).only_integer
     end
   end

--- a/spec/app/models/metasploit_data_models/ip_address/v4/segment/single_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/segment/single_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Segment::Single, type: :mode
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       allow(single).to receive(:value).and_return(value)
     end
 

--- a/spec/app/models/metasploit_data_models/ip_address/v4/single_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/single_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Single, type: :model do
   }
 
   context 'validation' do
-    before(:each) do
+    before(:example) do
       single.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/module_run_spec.rb
+++ b/spec/app/models/metasploit_data_models/module_run_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe MetasploitDataModels::ModuleRun, type: :model do
 
   context "validations" do
     describe "when a target_session is set on the module run" do
-      before(:each) do
+      before(:example) do
         module_run.target_session = FactoryGirl.build(:mdm_session)
       end
 
       context "when the module is an exploit" do
         context "and that exploit IS NOT local" do
-          before(:each) do
+          before(:example) do
             module_run.module_fullname = 'exploit/windows/mah-crazy-exploit'
           end
 
@@ -47,7 +47,7 @@ RSpec.describe MetasploitDataModels::ModuleRun, type: :model do
         end
 
         context "and that exploit IS local" do
-          before(:each) do
+          before(:example) do
             module_run.module_fullname = 'exploit/windows/local/mah-crazy-exploit'
           end
 
@@ -57,14 +57,14 @@ RSpec.describe MetasploitDataModels::ModuleRun, type: :model do
     end
 
     describe "when a spawned_session is set on the module run" do
-      before(:each) do
+      before(:example) do
         module_run.spawned_session  = FactoryGirl.build(:mdm_session)
       end
 
       context "when the module is not an exploit" do
 
         context "and it IS NOT a login scanner" do
-          before(:each) do
+          before(:example) do
             module_run.module_fullname = 'post/multi/gather/steal-minecraft-maps'
           end
 
@@ -72,7 +72,7 @@ RSpec.describe MetasploitDataModels::ModuleRun, type: :model do
         end
 
         context "and it IS a login scanner" do
-          before(:each) do
+          before(:example) do
             module_run.module_fullname = 'auxiliary/scanner/ssh/ssh_login'
           end
 
@@ -82,14 +82,14 @@ RSpec.describe MetasploitDataModels::ModuleRun, type: :model do
     end
 
     describe "attempted_at" do
-      before(:each){ module_run.attempted_at = nil }
+      before(:example){ module_run.attempted_at = nil }
 
       it { is_expected.to_not be_valid } 
     end
 
     describe "content information" do
       context "when there is no module_name" do
-        before(:each) do
+        before(:example) do
           module_run.module_fullname = nil
         end
 
@@ -100,7 +100,7 @@ RSpec.describe MetasploitDataModels::ModuleRun, type: :model do
 
     describe "status" do
       describe "invalidity" do
-        before(:each) do
+        before(:example) do
           module_run.status = "invalid nonsense"
         end
 
@@ -109,19 +109,19 @@ RSpec.describe MetasploitDataModels::ModuleRun, type: :model do
 
       describe "validity" do
         context "when the module run succeeded" do
-          before(:each){ module_run.status = MetasploitDataModels::ModuleRun::SUCCEED}
+          before(:example){ module_run.status = MetasploitDataModels::ModuleRun::SUCCEED}
 
           it{ expect(module_run).to be_valid }
         end
 
         context "when the module run went normally but failed" do
-          before(:each){ module_run.status = MetasploitDataModels::ModuleRun::FAIL}
+          before(:example){ module_run.status = MetasploitDataModels::ModuleRun::FAIL}
 
           it{ expect(module_run).to be_valid }
         end
 
         context "when the module run errored out" do
-          before(:each){ module_run.status = MetasploitDataModels::ModuleRun::ERROR}
+          before(:example){ module_run.status = MetasploitDataModels::ModuleRun::ERROR}
 
           it{ expect(module_run).to be_valid }
         end

--- a/spec/app/models/metasploit_data_models/search/operation/ip_address_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/operation/ip_address_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe MetasploitDataModels::Search::Operation::IPAddress, type: :model 
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       operation.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/search/operation/port/range_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/operation/port/range_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MetasploitDataModels::Search::Operation::Port::Range, type: :mode
   it { is_expected.to be_a MetasploitDataModels::Search::Operation::Range }
 
   context 'validations' do
-    before(:each) do
+    before(:example) do
       port_range_operation.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/search/operation/range_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/operation/range_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe MetasploitDataModels::Search::Operation::Range, type: :model do
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       range_operation.valid?
     end
 

--- a/spec/app/models/metasploit_data_models/search/operator/port/list_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/operator/port/list_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe MetasploitDataModels::Search::Operator::Port::List, type: :model 
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         port_list_operator.attribute = value
       end
 
@@ -143,7 +143,7 @@ RSpec.describe MetasploitDataModels::Search::Operator::Port::List, type: :model 
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       port_list_operator.attribute = attribute
     end
 

--- a/spec/app/models/metasploit_data_models/search/visitor/relation_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/visitor/relation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe MetasploitDataModels::Search::Visitor::Relation, type: :model do
             double('Query')
           end
 
-          before(:each) do
+          before(:example) do
             allow(query).to receive(:valid?).and_return(query)
 
             visitor.valid?

--- a/spec/app/validators/parameters_validator_spec.rb
+++ b/spec/app/validators/parameters_validator_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe ParametersValidator do
         ''
       end
 
-      before(:each) do
+      before(:example) do
         validate_each
       end
 

--- a/spec/lib/metasploit_data_models/ip_address/cidr_spec.rb
+++ b/spec/lib/metasploit_data_models/ip_address/cidr_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe MetasploitDataModels::IPAddress::CIDR, type: :model do
   # Callbacks
   #
 
-  before(:each) do
+  before(:example) do
     stub_const('IncludingClass', including_class)
   end
 
@@ -83,7 +83,7 @@ RSpec.describe MetasploitDataModels::IPAddress::CIDR, type: :model do
   end
 
   context 'validation errors on' do
-    before(:each) do
+    before(:example) do
       including_class_instance.valid?
     end
 
@@ -173,7 +173,7 @@ RSpec.describe MetasploitDataModels::IPAddress::CIDR, type: :model do
       including_class.match_regexp
     }
 
-    before(:each) do
+    before(:example) do
       expect(including_class).to receive(:regexp).and_return(/regexp/)
     end
 

--- a/spec/lib/metasploit_data_models/ip_address/cidr_spec.rb
+++ b/spec/lib/metasploit_data_models/ip_address/cidr_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe MetasploitDataModels::IPAddress::CIDR, type: :model do
         segment_count * segment_bits
       }
 
-      it 'validates it is an integer between 0 and maximum_prefix_length', pending: 'https://github.com/thoughtbot/shoulda-matchers/issues/784' do
+      it 'validates it is an integer between 0 and maximum_prefix_length' do
         expect(including_class_instance).to validate_numericality_of(:prefix_length).only_integer.is_greater_than_or_equal_to(0).is_less_than_or_equal_to(maximum_prefix_length)
       end
     end

--- a/spec/lib/metasploit_data_models/ip_address/range_spec.rb
+++ b/spec/lib/metasploit_data_models/ip_address/range_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe MetasploitDataModels::IPAddress::Range do
         range.send(extreme)
       }
 
-      before(:each) do
+      before(:example) do
         allow(range).to receive(:value).and_return(value)
       end
 

--- a/spec/lib/metasploit_data_models/match/child_spec.rb
+++ b/spec/lib/metasploit_data_models/match/child_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MetasploitDataModels::Match::Child do
     }
   }
 
-  before(:each) do
+  before(:example) do
     stub_const('ExtendingClass', extending_class)
     stub_const('ExtendingClass::REGEXP', /\d+-\d+/)
   end

--- a/spec/lib/metasploit_data_models/match/parent_spec.rb
+++ b/spec/lib/metasploit_data_models/match/parent_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe MetasploitDataModels::Match::Parent do
     # Callbacks
     #
 
-    before(:each) do
+    before(:example) do
       stub_const('NumberChild', number_child_class)
       stub_const('NumberChild::REGEXP', /\d+/)
 
@@ -123,7 +123,7 @@ RSpec.describe MetasploitDataModels::Match::Parent do
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         including_class.match_children_named child_classes.map(&:name)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,6 +127,17 @@ RSpec.configure do |config|
     # Rex is only available when testing with metasploit-framework or pro, so stub out the methods that require it
     allow_any_instance_of(Mdm::Workspace).to receive(:valid_ip_or_range?).and_return(true)
   end
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,7 +123,7 @@ RSpec.configure do |config|
 
   config.use_transactional_fixtures = true
 
-  config.before(:each) do
+  config.before(:example) do
     # Rex is only available when testing with metasploit-framework or pro, so stub out the methods that require it
     allow_any_instance_of(Mdm::Workspace).to receive(:valid_ip_or_range?).and_return(true)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,15 @@ RSpec.configure do |config|
   #       # Equivalent to being in spec/controllers
   #     end
   config.infer_spec_type_from_file_location!
+
+  # Setting this config option `false` removes rspec-core's monkey patching of the
+  # top level methods like `describe`, `shared_examples_for` and `shared_context`
+  # on `main` and `Module`. The methods are always available through the `RSpec`
+  # module like `RSpec.describe` regardless of this setting.
+  # For backwards compatibility this defaults to `true`.
+  #
+  # https://relishapp.com/rspec/rspec-core/v/3-0/docs/configuration/global-namespace-dsl
+  config.expose_dsl_globally = false
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/matchers/match_regex_exactly.rb
+++ b/spec/support/matchers/match_regex_exactly.rb
@@ -1,6 +1,6 @@
 # Checks that the string matches the
 RSpec::Matchers.define :match_string_exactly do |string|
-  failure_message_for_should do |regexp|
+  failure_message do |regexp|
     match = regexp.match(string)
 
     failure_message = "expected #{regexp} to match #{string}"

--- a/spec/support/shared/contexts/rex/text.rb
+++ b/spec/support/shared/contexts/rex/text.rb
@@ -1,5 +1,5 @@
 shared_context 'Rex::Text' do
-  before(:each) do
+  before(:example) do
     rex_text = Module.new do
       def self.ascii_safe_hex(str, whitespace=false)
         if whitespace

--- a/spec/support/shared/contexts/rex/text.rb
+++ b/spec/support/shared/contexts/rex/text.rb
@@ -1,4 +1,4 @@
-shared_context 'Rex::Text' do
+RSpec.shared_context 'Rex::Text' do
   before(:example) do
     rex_text = Module.new do
       def self.ascii_safe_hex(str, whitespace=false)

--- a/spec/support/shared/examples/coerces_inet_column_type_to_string.rb
+++ b/spec/support/shared/examples/coerces_inet_column_type_to_string.rb
@@ -4,7 +4,7 @@ shared_examples_for 'coerces inet column type to string' do |column|
   context 'with an inet column' do
     let(:address) { '10.0.0.1' }
 
-    before(:each) do
+    before(:example) do
       subject.update_attribute column, address
     end
 

--- a/spec/support/shared/examples/coerces_inet_column_type_to_string.rb
+++ b/spec/support/shared/examples/coerces_inet_column_type_to_string.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'coerces inet column type to string' do |column|
+RSpec.shared_examples_for 'coerces inet column type to string' do |column|
   raise ArgumentError, 'must pass the column name' unless column
 
   context 'with an inet column' do

--- a/spec/support/shared/examples/mdm/module/detail/does_not_support_stance_with_mtype.rb
+++ b/spec/support/shared/examples/mdm/module/detail/does_not_support_stance_with_mtype.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Mdm::Module::Detail does not support stance with mtype' do |mtype|
+RSpec.shared_examples_for 'Mdm::Module::Detail does not support stance with mtype' do |mtype|
   context "with #{mtype.inspect}" do
     # define as a let so that lets from outer context can access option to set detail.
     let(:mtype) do

--- a/spec/support/shared/examples/mdm/module/detail/supports_stance_with_mtype.rb
+++ b/spec/support/shared/examples/mdm/module/detail/supports_stance_with_mtype.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Mdm::Module::Detail supports stance with mtype' do |mtype|
+RSpec.shared_examples_for 'Mdm::Module::Detail supports stance with mtype' do |mtype|
   context "with #{mtype.inspect}" do
     # define as a let so that lets from outer context can access option to set detail.
     let(:mtype) do

--- a/spec/support/shared/examples/metasploit_data_models/search/operation/ipaddress/match.rb
+++ b/spec/support/shared/examples/metasploit_data_models/search/operation/ipaddress/match.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'MetasploitDataModels::Search::Operation::IPAddress::*.match' do |options={}|
+RSpec.shared_examples_for 'MetasploitDataModels::Search::Operation::IPAddress::*.match' do |options={}|
   options.assert_valid_keys(4, 6)
 
   subject(:match) {

--- a/spec/support/shared/examples/metasploit_data_models/search/visitor/includes/visit/with_children.rb
+++ b/spec/support/shared/examples/metasploit_data_models/search/visitor/includes/visit/with_children.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'MetasploitDataModels::Search::Visitor::Includes#visit with #children' do
+RSpec.shared_examples_for 'MetasploitDataModels::Search::Visitor::Includes#visit with #children' do
   let(:children) do
     2.times.collect { |n|
       double("Child #{n}")

--- a/spec/support/shared/examples/metasploit_data_models/search/visitor/includes/visit/with_metasploit_model_search_operation_base.rb
+++ b/spec/support/shared/examples/metasploit_data_models/search/visitor/includes/visit/with_metasploit_model_search_operation_base.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'MetasploitDataModels::Search::Visitor::Includes#visit with Metasploit::Model::Search::Operation::Base' do
+RSpec.shared_examples_for 'MetasploitDataModels::Search::Visitor::Includes#visit with Metasploit::Model::Search::Operation::Base' do
   let(:operator) do
     double('Operation Operator')
   end

--- a/spec/support/shared/examples/metasploit_data_models/search/visitor/relation/visit/matching_record.rb
+++ b/spec/support/shared/examples/metasploit_data_models/search/visitor/relation/visit/matching_record.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'MetasploitDataModels::Search::Visitor::Relation#visit matching record' do |options={}|
+RSpec.shared_examples_for 'MetasploitDataModels::Search::Visitor::Relation#visit matching record' do |options={}|
   options.assert_valid_keys(:attribute, :association)
 
   attribute = options.fetch(:attribute)

--- a/spec/support/shared/examples/metasploit_data_models/search/visitor/where/visit/with_equality.rb
+++ b/spec/support/shared/examples/metasploit_data_models/search/visitor/where/visit/with_equality.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'MetasploitDataModels::Search::Visitor::Where#visit with equality operation' do
+RSpec.shared_examples_for 'MetasploitDataModels::Search::Visitor::Where#visit with equality operation' do
   let(:node) do
     node_class.new(
         :operator => operator,

--- a/spec/support/shared/examples/metasploit_data_models/search/visitor/where/visit/with_metasploit_model_search_group_base.rb
+++ b/spec/support/shared/examples/metasploit_data_models/search/visitor/where/visit/with_metasploit_model_search_group_base.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'MetasploitDataModels::Search::Visitor::Where#visit with Metasploit::Model::Search*::Group::Base' do |options={}|
+RSpec.shared_examples_for 'MetasploitDataModels::Search::Visitor::Where#visit with Metasploit::Model::Search*::Group::Base' do |options={}|
   options.assert_valid_keys(:arel_class)
 
   arel_class = options.fetch(:arel_class)


### PR DESCRIPTION
Converts rspec to latests conventions and removes old invalid pending status from 4 specs

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no `[warn]`ings
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit_data_models/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`