### PR TITLE
Bug/ms 896/hash scope

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -498,9 +498,7 @@ class Mdm::Host < ActiveRecord::Base
           parameters = [formatted_parameter] * SEARCH_FIELDS.length
           conditions = [disjunction] + parameters
 
-          {
-              :conditions => conditions
-          }
+          where(*conditions)
         }
   scope :tag_search,
         lambda { |*args| where("tags.name" => args[0]).includes(:tags) }

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -12,7 +12,7 @@ module MetasploitDataModels
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 0
 
-    PRERELEASE = "Relation-all-deprecation"
+    PRERELEASE = "hash-scope"
     #
     # Module Methods
     #


### PR DESCRIPTION
Fixes the deprecation warning about using a hash in a model scope

Replaced the hash with a splatted where

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
- [x] VERIFY no deprecation warning about returning a hash from a scope

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin master`