### PR TITLE
MS-895: Fix Model.scoped deprecation

### DIFF
--- a/app/models/metasploit_data_models/search/visitor/relation.rb
+++ b/app/models/metasploit_data_models/search/visitor/relation.rb
@@ -42,7 +42,7 @@ class MetasploitDataModels::Search::Visitor::Relation < Metasploit::Model::Base
     tree = query.tree
 
     # Enumerable#inject does not support 3 arity for Hashes so need to unpack pair
-    visitor_by_relation_method.inject(query.klass.scoped) do |relation, pair|
+    visitor_by_relation_method.inject(query.klass.all) do |relation, pair|
       relation_method, visitor = pair
       visited = visitor.visit(tree)
       relation.send(relation_method, visited)

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -12,11 +12,7 @@ module MetasploitDataModels
     # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
     PATCH = 11
 
-
-    
-
-
-    
+    PRERELEASE = 'change-scoped-to-all'
     #
     # Module Methods
     #

--- a/spec/app/models/metasploit_data_models/search/visitor/relation_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/visitor/relation_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe MetasploitDataModels::Search::Visitor::Relation, type: :model do
         visited = double('Visited')
         allow(includes_visitor).to receive(:visit).with(query.tree).and_return(visited)
 
-        expect_any_instance_of(ActiveRecord::Relation).to receive(:includes).with(visited).and_return(query.klass.scoped)
+        expect_any_instance_of(ActiveRecord::Relation).to receive(:includes).with(visited).and_return(query.klass.all)
 
         visit
       end
@@ -126,7 +126,7 @@ RSpec.describe MetasploitDataModels::Search::Visitor::Relation, type: :model do
         visited = double('Visited')
         allow(joins_visitor).to receive(:visit).with(query.tree).and_return(visited)
 
-        expect_any_instance_of(ActiveRecord::Relation).to receive(:joins).with(visited).and_return(query.klass.scoped)
+        expect_any_instance_of(ActiveRecord::Relation).to receive(:joins).with(visited).and_return(query.klass.all)
 
         visit
       end
@@ -147,7 +147,7 @@ RSpec.describe MetasploitDataModels::Search::Visitor::Relation, type: :model do
         visited = double('Visited')
         allow(where_visitor).to receive(:visit).with(query.tree).and_return(visited)
 
-        expect_any_instance_of(ActiveRecord::Relation).to receive(:where).with(visited).and_return(query.klass.scoped)
+        expect_any_instance_of(ActiveRecord::Relation).to receive(:where).with(visited).and_return(query.klass.all)
 
         visit
       end


### PR DESCRIPTION
# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no `[warn]`ings
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to DESTINATION or the build will be broke on DESTINATION.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Change `PRERELEASE` from `SOURCE_SUMMARY` to `DESTINATION_SUMMARY` to match the branch (DESTINATION) summary (DESTINATION_SUMMARY)

## Gem build
- [x] gem build metasploit_data_models.gemspec
- [x] VERIFY the prerelease suffix has change on the gem.

## RSpec
- [x] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [x] `git commit -a`
- [x] `git push origin DESTINATION`