### PR TITLE
Bug/ms 899/string sql eager load

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -486,7 +486,7 @@ class Mdm::Host < ActiveRecord::Base
   #
 
   scope :alive, -> { where({'hosts.state' => 'alive'}) }
-  scope :flagged, -> { where('notes.critical = true AND notes.seen = false').includes(:notes) }
+  scope :flagged, -> { where('notes.critical = true AND notes.seen = false').includes(:notes).references(:notes) }
   scope :search,
         lambda { |*args|
           # @todo replace with AREL
@@ -503,7 +503,7 @@ class Mdm::Host < ActiveRecord::Base
           }
         }
   scope :tag_search,
-        lambda { |*args| where("tags.name" => args[0]).includes(:tags) }
+        lambda { |*args| where("tags.name" => args[0]).includes(:tags).references(:tags) }
 
   #
   #

--- a/app/models/mdm/vuln.rb
+++ b/app/models/mdm/vuln.rb
@@ -181,7 +181,7 @@ class Mdm::Vuln < ActiveRecord::Base
       )
     ).includes(
       :refs, :host
-    )
+    ).references(:refs,:host)
   }
 
   #

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -13,7 +13,7 @@ module MetasploitDataModels
     PATCH = 11
 
 
-    
+    PRERELEASE = 'string-sql-eager-load'
 
 
     


### PR DESCRIPTION
# Verification Steps

MS-899

DEPRECATION WARNING: It looks like you are eager loading table(s) that are referenced in a string SQL snippet.

# Verification Steps

- [x] `bundle install`

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## `rake yard`
- [x] `rake yard`
- [x] VERIFY no undocumented objects

# Post-merge Steps

Perform these steps prior to pushing to rails-4-deprecations or the build will be broke on rails-4-deprecations.

## Version
- [x] Edit `lib/metasploit_data_models/version.rb`
- [x] Edit `PRERELEASE` set it to
```
PRERELEASE = "rails-4.0-dev"
```
## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Releasing

## Release to rubygems.org

## ruby-2.1
- [ ] `rvm use ruby-2.1@metasploit_data_models`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`