### PR TITLE
Fix eager loading table(s) that are referenced in a string SQL snippe…

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -486,7 +486,7 @@ class Mdm::Host < ActiveRecord::Base
   #
 
   scope :alive, -> { where({'hosts.state' => 'alive'}) }
-  scope :flagged, -> { where('notes.critical = true AND notes.seen = false').includes(:notes) }
+  scope :flagged, -> { where('notes.critical = true AND notes.seen = false').includes(:notes).references(:notes) }
   scope :search,
         lambda { |*args|
           # @todo replace with AREL
@@ -501,7 +501,7 @@ class Mdm::Host < ActiveRecord::Base
           where(*conditions)
         }
   scope :tag_search,
-        lambda { |*args| where("tags.name" => args[0]).includes(:tags) }
+        lambda { |*args| where("tags.name" => args[0]).includes(:tags).references(:tags) }
 
   #
   #

--- a/app/models/mdm/vuln.rb
+++ b/app/models/mdm/vuln.rb
@@ -181,7 +181,7 @@ class Mdm::Vuln < ActiveRecord::Base
       )
     ).includes(
       :refs, :host
-    )
+    ).references(:refs,:host)
   }
 
   #


### PR DESCRIPTION
*Cherry picked commit with actual MS-899 fix. We need to merge into staging/rails-upgrade because it was merged into staging/rails-4.0-deprecations instead. https://github.com/rapid7/metasploit_data_models/pull/150

DEPRECATION WARNING: It looks like you are eager loading table(s) that are referenced in a string SQL snippet.

# Verification Steps

- [ ] `bundle install`

## `rake spec`
- [ ] `rake spec`
- [ ] VERIFY no failures

## `rake yard`
- [ ] `rake yard`
- [ ] VERIFY no undocumented objects