### PR TITLE
explitly call to_a on relation

### DIFF
--- a/app/models/mdm/workspace.rb
+++ b/app/models/mdm/workspace.rb
@@ -295,7 +295,7 @@ class Mdm::Workspace < ActiveRecord::Base
   def web_unique_forms(addrs=nil)
     forms = unique_web_forms
     if addrs
-      forms.reject!{|f| not addrs.include?( f.web_site.service.host.address.to_s ) }
+      forms.to_a.reject!{|f| not addrs.include?( f.web_site.service.host.address.to_s ) }
     end
     forms
   end


### PR DESCRIPTION
the unique web forms method was expecting an implicit
to_a on a relation before calling #reject! change this
to an explicit to_a to fix the error

MS-1235

VERIFICATION STEPS
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY all specs pass