### PR TITLE
update gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,17 +22,14 @@ group :development, :test do
   gem 'coveralls', require: false  
   # supplies factories for producing model instance for specs
   # Version 4.1.0 or newer is needed to support generate calls without the 'FactoryGirl.' in factory definitions syntax.
-  gem 'factory_girl', '>= 4.1.0'
+  gem 'factory_girl'
   # running documentation generation tasks and rspec tasks
-  gem 'rake', '~> 10.5'
+  gem 'rake'
   # auto-load factories from spec/factories
   gem 'factory_girl_rails'
 
-  rails_version_constraint = [
-      '>= 4.1',
-      '< 4.2'
-  ]
-  gem 'rails', *rails_version_constraint
+
+  gem 'rails', '~>4.1.15'
   # Used to create fake data
   gem "faker"
 end
@@ -41,12 +38,12 @@ group :test do
   # In a full rails project, factory_girl_rails would be in both the :development, and :test group, but since we only
   # want rails in :test, factory_girl_rails must also only be in :test.
   # add matchers from shoulda, such as validates_presence_of, which are useful for testing validations
-  gem 'shoulda-matchers', '~> 3.0'
+  gem 'shoulda-matchers'
   # code coverage of tests
   gem 'simplecov', :require => false
   # need rspec-rails >= 2.12.0 as 2.12.0 adds support for redefining named subject in nested context that uses the
   # named subject from the outer context without causing a stack overflow.
-  gem 'rspec-rails', '~> 3.2'
+  gem 'rspec-rails'
   # used for building markup for webpage factories
   gem 'builder'
 end

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -43,13 +43,12 @@ Gem::Specification.new do |s|
   # debugging
   s.add_development_dependency 'pry'
 
-  rails_version_constraints = ['>= 4.1', '< 4.2']
 
-  s.add_runtime_dependency 'activerecord', *rails_version_constraints
-  s.add_runtime_dependency 'activesupport', *rails_version_constraints
+  s.add_runtime_dependency 'activerecord', '~>4.1.15'
+  s.add_runtime_dependency 'activesupport', '~>4.1.15'
   s.add_runtime_dependency 'metasploit-concern' #, '~> 1.1'
   s.add_runtime_dependency 'metasploit-model' #, '~> 1.1'
-  s.add_runtime_dependency 'railties', *rails_version_constraints
+  s.add_runtime_dependency 'railties', '~>4.1.15'
 
   # os fingerprinting
   s.add_runtime_dependency 'recog', '~> 2.0'


### PR DESCRIPTION
unlock all the gem versions that we can
for rails 4.1 support

MS-1330

VERIFICATION STEPS
- [x] `rm Gemfile.lock`
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY all specs pass