### PR TITLE
Update MDM to allow passthough for Unicode domain names

### DIFF
--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -453,16 +453,11 @@ module Mdm::Host::OperatingSystemNormalization
   # exposed services and rename to guess_purpose_with_match()
   #
   def guess_purpose_from_match(match)
-    #
-    # The regex below relies on ANSI characters, so we must ensure that
-    # pstr is populated with ANSI chars so it can be searched correctly
-    #
-    pstr = "".encode("ASCII-8BIT")
+    # some data that is sent to this is numeric; we do not want that
+    pstr = ""
     match.values.each do |i|
       if i.respond_to?(:encoding)
-        if i.encoding.name == "ASCII-8BIT"
-          pstr << (i.downcase + ' ')
-        end
+        pstr << (i.downcase + ' ')
       end
     end
     # Loosely map keywords to specific purposes

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -446,7 +446,6 @@ module Mdm::Host::OperatingSystemNormalization
         host.mac = host.mac.scan(/../).join(':')
       end
     end
-
   end
 
   #

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -453,14 +453,15 @@ module Mdm::Host::OperatingSystemNormalization
   # exposed services and rename to guess_purpose_with_match()
   #
   def guess_purpose_from_match(match)
-    # Create a string based on all match values
-    pstr = ""
+    #
+    # The regex below relies on ANSI characters, so we must ensure that
+    # pstr is populated with ANSI chars so it can be searched correctly
+    #
+    pstr = "".encode("ASCII-8BIT")
     match.values.each do |i|
-      # we need to only add lowercase ANSI text to the pstr, so skip
-      # anything that has no "encoding"
       if i.respond_to?(:encoding)
         if i.encoding.name == "ASCII-8BIT"
-          pstr << i.downcase + ' '
+          pstr << (i.downcase + ' ')
         end
       end
     end
@@ -468,7 +469,7 @@ module Mdm::Host::OperatingSystemNormalization
     case pstr
     when /windows server|windows (nt|20)/
       'server'
-    when /windows (xp|vista|[78])/
+    when /windows (xp|vista|[78]|10)/
       'client'
     when /printer|print server/
       'printer'

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -455,9 +455,17 @@ module Mdm::Host::OperatingSystemNormalization
   def guess_purpose_from_match(match)
     # some data that is sent to this is numeric; we do not want that
     pstr = ""
+    # Go through each character of each value and make sure it is all
+    # UTF-8
     match.values.each do |i|
       if i.respond_to?(:encoding)
-        pstr << (i.downcase + ' ')
+        i.each_char do |j|
+          begin
+            pstr << j.downcase.encode("UTF-8")
+          rescue Encoding::UndefinedConversionError => e
+            elog("Found incompatible (non-ANSI) character in guess_purpose_from_match")
+          end
+        end
       end
     end
     # Loosely map keywords to specific purposes

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -366,6 +366,7 @@ module Mdm::Host::OperatingSystemNormalization
   #
   def apply_match_to_host(match)
     host = self
+#    puts("IN apply_match_to_host: #{match}")
 
     # These values in a match always override the current value unless
     # the host attribute has been explicitly locked by the user
@@ -455,8 +456,16 @@ module Mdm::Host::OperatingSystemNormalization
   #
   def guess_purpose_from_match(match)
     # Create a string based on all match values
-    pstr = match.values.join(' ').downcase
-
+    pstr = nil
+    match.values.each do |i|
+      begin
+        if i.encoding.name == "ASCII-8-BIT"
+          pstr << i.downcase + ' '
+        end
+      rescue NameError => e
+        # If the element cannot be checked for encoding, we do not want it.
+      end
+    end
     # Loosely map keywords to specific purposes
     case pstr
     when /windows server|windows (nt|20)/

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -454,14 +454,14 @@ module Mdm::Host::OperatingSystemNormalization
   #
   def guess_purpose_from_match(match)
     # Create a string based on all match values
-    pstr = nil
+    pstr = ""
     match.values.each do |i|
-      begin
-        if i.encoding.name == "ASCII-8-BIT"
+      # we need to only add lowercase ANSI text to the pstr, so skip
+      # anything that has no "encoding"
+      if i.respond_to?(:encoding)
+        if i.encoding.name == "ASCII-8BIT"
           pstr << i.downcase + ' '
         end
-      rescue NameError => e
-        # If the element cannot be checked for encoding, we do not want it.
       end
     end
     # Loosely map keywords to specific purposes

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -366,7 +366,6 @@ module Mdm::Host::OperatingSystemNormalization
   #
   def apply_match_to_host(match)
     host = self
-#    puts("IN apply_match_to_host: #{match}")
 
     # These values in a match always override the current value unless
     # the host attribute has been explicitly locked by the user

--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -463,7 +463,8 @@ module Mdm::Host::OperatingSystemNormalization
           begin
             pstr << j.downcase.encode("UTF-8")
           rescue Encoding::UndefinedConversionError => e
-            elog("Found incompatible (non-ANSI) character in guess_purpose_from_match")
+            # this works in Framework, but causes a Travis CI error
+            # elog("Found incompatible (non-ANSI) character in guess_purpose_from_match")
           end
         end
       end


### PR DESCRIPTION
# This PR is required by an accompanying framework PR

# What does this change accomplish?
This change allows metasploit data models to accept Unicode data and allows it to pass the data to the database correctly.  Specifically, this change prevents  the Unicode domain and hostname data to be fed into an ANSI matching function that attempts to determine computer use.  Primarily, this determination is made from attempting to match on the the operating system name and type, so loss of the hostname and domain data should not affect the purpose determination.  

## testing
Testing requires access to domain-joined targets is listed in the dependent metasploit framework, and should be done in conjunction with the associated framework PR.