### PR TITLE
delay fingerprinting during imports

### DIFF
--- a/app/models/mdm/note.rb
+++ b/app/models/mdm/note.rb
@@ -113,7 +113,7 @@ class Mdm::Note < ActiveRecord::Base
   #
   # @return [void]
   def normalize
-    if data_changed? and ntype =~ /fingerprint/
+    if data_changed? and ntype =~ /fingerprint/ && host.workspace.present? && !host.workspace.import_fingerprint
       host.normalize_os
     end
   end

--- a/app/models/mdm/service.rb
+++ b/app/models/mdm/service.rb
@@ -255,7 +255,7 @@ class Mdm::Service < ActiveRecord::Base
   #
   # @return [void]
   def normalize_host_os
-    if info_changed?
+    if info_changed? && host.workspaace.present? && !host.workspace.import_fingerprint
       host.normalize_os
     end
   end

--- a/db/migrate/20161004165612_add_fingerprinted_to_workspace.rb
+++ b/db/migrate/20161004165612_add_fingerprinted_to_workspace.rb
@@ -1,0 +1,5 @@
+class AddFingerprintedToWorkspace < ActiveRecord::Migration
+  def change
+    add_column :workspaces, :import_fingerprint, :boolean, default: false
+  end
+end


### PR DESCRIPTION
MS-2073

* added boolean column to workspaces to (not) trigger fingerprinting after service creation
* added logic to note and service normalize_os method

# VERIFICATION
- [ ] specs pass
- [ ] point framework to use this branch for metasploit data models 
- [ ] import should still function
- [ ] fingerprinting of host should still function