### PR TITLE
Upgrade MDM to ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - graphviz
 language: ruby
 rvm:
-  - 2.2.4
+  - '2.3.1'
 before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
   - bundle exec rake --version

--- a/config/initializers/ipaddr.rb
+++ b/config/initializers/ipaddr.rb
@@ -18,7 +18,7 @@ module IPAddrExtensions
     begin
       spaceship_without_rescue(other)
     rescue ArgumentError
-      false
+      nil
     end
   end
 
@@ -26,7 +26,7 @@ module IPAddrExtensions
     begin
       include_without_rescue?(other)
     rescue ArgumentError
-      false
+      nil
     end
   end
 


### PR DESCRIPTION
Framework and Pro are on 2.3.1, so we should upgrade here, too.
# Verification
- [ ] Current master does not pass specs using ruby 2.3.1
- [ ] This branch should pass
