### PR TITLE
Update ipaddr monkeypatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 group: stable
-bundler_args: --without coverage development pcap
 cache: bundler
 addons:
   postgresql: '9.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
 language: ruby
 rvm:
   - '2.3.1'
-  - '2.2.4'
   
 before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
-addons:
-  postgresql: '9.5'
-group: stable
 sudo: false
+group: stable
+bundler_args: --without coverage development pcap
 cache: bundler
 addons:
+  postgresql: '9.3'
   apt:
     packages:
+      - libpcap-dev
       - graphviz
 language: ruby
 rvm:
-  - 2.2.4
+  - '2.3.1'
+  - '2.2.4'
+  
 before_script:
   - cp spec/dummy/config/database.yml.travis spec/dummy/config/database.yml
   - bundle exec rake --version
   - bundle exec rake db:create db:migrate
-script: bundle exec rake spec yard
+script:
+  - git diff --exit-code spec/dummy/db/structure.sql
+  - bundle exec rake spec yard

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ before_script:
   - bundle exec rake db:create db:migrate
 script:
   - git diff --exit-code spec/dummy/db/structure.sql
-  - bundle exec rake spec yard
+  - bundle exec rake spec
+  - bundle exec rake yard

--- a/config/initializers/ipaddr.rb
+++ b/config/initializers/ipaddr.rb
@@ -1,35 +1,24 @@
 module IPAddrExtensions
   extend ActiveSupport::Concern
   included do
-    begin
-      remove_method :==
-    rescue NameError => e
-      puts e.message
-    end
-    
-    alias_method :spaceship_without_rescue, :<=>
-    alias_method :<=>, :spaceship_with_rescue
-    
-    alias_method_chain :include?, :rescue
+    alias_method_chain :coerce_other, :rescue
   end
   
-
-  def spaceship_with_rescue(other)
+  def coerce_other_with_rescue(other)
     begin
-      spaceship_without_rescue(other)
-    rescue ArgumentError
-      false
+      case other
+      when IPAddr
+        other
+      when String
+        self.class.new(other)
+      else
+        self.class.new(other, @family)
+      end
+    rescue ArgumentError => e
+      OpenStruct.new(family: false, to_i: false)
     end
   end
-
-  def include_with_rescue?(other)
-    begin
-      include_without_rescue?(other)
-    rescue ArgumentError
-      false
-    end
-  end
-
+  
 end
 
 IPAddr.send(:include, IPAddrExtensions)

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -1970,7 +1970,8 @@ CREATE TABLE workspaces (
     boundary character varying(4096),
     description character varying(4096),
     owner_id integer,
-    limit_to_network boolean DEFAULT false NOT NULL
+    limit_to_network boolean DEFAULT false NOT NULL,
+    import_fingerprint boolean DEFAULT false
 );
 
 
@@ -3393,6 +3394,8 @@ INSERT INTO schema_migrations (version) VALUES ('20150421211719');
 INSERT INTO schema_migrations (version) VALUES ('20150514182921');
 
 INSERT INTO schema_migrations (version) VALUES ('20160415153312');
+
+INSERT INTO schema_migrations (version) VALUES ('20161004165612');
 
 INSERT INTO schema_migrations (version) VALUES ('21');
 


### PR DESCRIPTION
## Verification steps
 - [ ] on master verify you get the following error with ruby 2.3.1
```
IPAddr.new('10.0.0.1') == 'foo'
(irb):1: warning: Comparable#== will no more rescue exceptions of #<=> in the next release.
(irb):1: warning: Return nil in #<=> if the comparison is inappropriate or avoid such comparison.
```
 - [ ] checkout this branch and run the same command 
```
IPAddr.new('10.0.0.1') == 'foo'
```
 - [ ] review the changes made to .travis.yml