### PR TITLE
Ensure valid port settings when adding a service to a host.

### DIFF
--- a/app/models/mdm/service.rb
+++ b/app/models/mdm/service.rb
@@ -218,6 +218,9 @@ class Mdm::Service < ActiveRecord::Base
   validates :port,
             numericality: {
                 only_integer: true
+            },
+            inclusion: {
+                in: 1..65535
             }
   validates :port,
             uniqueness: {

--- a/spec/app/models/mdm/service_spec.rb
+++ b/spec/app/models/mdm/service_spec.rb
@@ -176,6 +176,39 @@ RSpec.describe Mdm::Service, type: :model do
   end
 
   context "validations" do
+
+    context 'port' do
+      it 'should require a port' do
+        portless_service= FactoryGirl.build(:mdm_service, :port => nil)
+        expect(portless_service).not_to be_valid
+        expect(portless_service.errors[:port]).to include("is not a number")
+      end
+
+      it 'should not be valid for out-of-range numbers' do
+        out_of_range = FactoryGirl.build(:mdm_service, :port => 70000)
+        expect(out_of_range).not_to be_valid
+        expect(out_of_range.errors[:port]).to include("is not included in the list")
+      end
+
+      it 'should not be valid for port 0' do
+        out_of_range = FactoryGirl.build(:mdm_service, :port => 0)
+        expect(out_of_range).not_to be_valid
+        expect(out_of_range.errors[:port]).to include("is not included in the list")
+      end
+
+      it 'should not be valid for decimal numbers' do
+        out_of_range = FactoryGirl.build(:mdm_service, :port => 5.67)
+        expect(out_of_range).not_to be_valid
+        expect(out_of_range.errors[:port]).to include("must be an integer")
+      end
+
+      it 'should not be valid for a negative number' do
+        out_of_range = FactoryGirl.build(:mdm_service, :port => -8)
+        expect(out_of_range).not_to be_valid
+        expect(out_of_range.errors[:port]).to include("is not included in the list")
+      end
+    end
+
     subject(:mdm_service) {
       FactoryGirl.build(:mdm_service)
     }


### PR DESCRIPTION
This fix ensures a valid port number is provided when a user creates a service on a host.  This was logged against Metasploit Pro and can be verified against Metasploit Pro.

See MS-2216.

-----

# Verification

- [x] log in to the Metasploit Pro UI
- [x] under Project Listing, click any workspace which has at least one host
- [x] under Discovery, select the "X hosts discovered" link
- [x] click a host IP address
- [x] click the New Service button
- [x] try creating services with invalid port numbers (some examples would be using non-numeric characters, negative numbers, decimal numbers, numbers outside the 1-65535 inclusive range)
- [x] **verify** that invalid port values are not accepted and, instead, display an accurate error
- [x] **verify** [Travis build](https://travis-ci.org/rapid7/metasploit_data_models/jobs/192843793) passed the updated rspec tests