### PR TITLE
Speeds up workspace deletion

### DIFF
--- a/app/models/mdm/host.rb
+++ b/app/models/mdm/host.rb
@@ -107,7 +107,7 @@ class Mdm::Host < ActiveRecord::Base
   #   @return [ActiveRecord::Relation<Mdm::Event>]
   has_many :events,
            class_name: 'Mdm::Event',
-           dependent: :destroy,
+           dependent: :delete_all,
            inverse_of: :host
 
   # @!attribute [rw] task_hosts

--- a/app/models/mdm/workspace.rb
+++ b/app/models/mdm/workspace.rb
@@ -28,7 +28,7 @@ class Mdm::Workspace < ActiveRecord::Base
   has_many :creds, :through => :services, :class_name => 'Mdm::Cred'
 
   # Events that occurred in this workspace.
-  has_many :events, :class_name => 'Mdm::Event'
+  has_many :events, dependent: :delete_all, :class_name => 'Mdm::Event'
 
   # Hosts in this workspace.
   has_many :hosts, :dependent => :destroy, :class_name => 'Mdm::Host'

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.1
+-- Dumped from database version 9.6.3
+-- Dumped by pg_dump version 9.6.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
when a workspace has a lot of session events and events it can take a LONG time to delete

instead of instanciating each object and calling destroy I'm switching it over to delete_all
which happens in the database. this is a valid stratagy because these two models dont have any
hooks around deletion and they dont have any has_many relationships (so no orphaned grand children)

## Verification Steps

### From Framework master
- [ ] in framework create a workspace with 20k+ events and session events
- [ ] run `./msfconsole'
- [ ] run `workspace -D` it should take a long time to complete, you can cancel the process after a couple seconds

### Testing this change
- [ ] in framework change the Gemfile to point to this branch
- [ ] `bundle install`
- [ ] run `./msfconsole'
- [ ] run `workspace -D` it should delete in a few seconds.