### PR TITLE
Utilize SMB native LM results for fingerprinting, if available

### DIFF
--- a/lib/mdm/host/operating_system_normalization.rb
+++ b/lib/mdm/host/operating_system_normalization.rb
@@ -253,6 +253,7 @@ module Mdm::Host::OperatingSystemNormalization
     fingerprint_note_match_keys = {
       'smb.fingerprint'  => {
         :native_os               => [ 'smb.native_os' ],
+        :native_lm               => [ 'smb.native_lm' ],
       },
       'http.fingerprint' => {
         :header_server           => [ 'http_header.server', 'apache_os' ],


### PR DESCRIPTION
Untested.  I suspect the contributing steps have changed but the documentation hasn't.

Required for https://github.com/rapid7/metasploit-framework/pull/8452