### PR TITLE
update tests for latest version of factory-bot

### DIFF
--- a/spec/factories/mdm/creds.rb
+++ b/spec/factories/mdm/creds.rb
@@ -5,9 +5,9 @@ FactoryBot.define do
     #
     association :service, :factory => :mdm_service
 
-    active true
+    active { true }
     pass{ generate :mdm_cred_pass }
-    ptype 'password'
+    ptype { 'password' }
     user{ generate :mdm_user_username }
   end
 

--- a/spec/factories/mdm/nexpose_consoles.rb
+++ b/spec/factories/mdm/nexpose_consoles.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     port { generate :mdm_tcp_port }
     address { generate :mdm_ipv4_address }
     username {'ConsoleUser'}
-    password 's0meH4rdP4ssW0rd'
+    password { 's0meH4rdP4ssW0rd' }
   end
 
   sequence :mdm_nexpose_console_name do |n|

--- a/spec/factories/mdm/services.rb
+++ b/spec/factories/mdm/services.rb
@@ -11,10 +11,10 @@ FactoryBot.define do
     name { generate :mdm_service_name }
     port { generate :port }
     proto { generate :mdm_service_proto }
-    state 'open'
+    state { 'open' }
 
     factory :web_service do
-      proto 'tcp'
+      proto { 'tcp' }
       name { FactoryBot.generate(:web_service_name) }
     end
   end

--- a/spec/factories/mdm/users.rb
+++ b/spec/factories/mdm/users.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :mdm_user, :class => Mdm::User do
-    admin true
-    company "Interplanetary Teleportation, LTD"
-    email "rwillingham@itl.com"
+    admin { true }
+    company { "Interplanetary Teleportation, LTD" }
+    email { "rwillingham@itl.com" }
     fullname { generate :mdm_user_fullname }
-    phone "5123334444"
+    phone { "5123334444" }
     username { generate :mdm_user_username }
   end
 
   factory :non_admin_mdm_user, :parent => :mdm_user do
-    admin false
+    admin { false }
   end
 
   sequence :mdm_user_fullname do |n|

--- a/spec/factories/metasploit_data_models/automatic_exploitation/match_results.rb
+++ b/spec/factories/metasploit_data_models/automatic_exploitation/match_results.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :automatic_exploitation_match_result, :class => 'MetasploitDataModels::AutomaticExploitation::MatchResult' do
     association :match, factory: :automatic_exploitation_match
     association :run, factory: :automatic_exploitation_run
-    state "succeeded"
+    state { "succeeded" }
   end
 end

--- a/spec/factories/module_runs.rb
+++ b/spec/factories/module_runs.rb
@@ -6,24 +6,24 @@ FactoryBot.define do
     association :user, factory: :mdm_user
 
     trait :failed do
-      status MetasploitDataModels::ModuleRun::FAIL
+      status { MetasploitDataModels::ModuleRun::FAIL }
     end
 
     trait :exploited do
-      status MetasploitDataModels::ModuleRun::SUCCEED
+      status { MetasploitDataModels::ModuleRun::SUCCEED }
     end
 
     trait :error do
-      status MetasploitDataModels::ModuleRun::ERROR
+      status { MetasploitDataModels::ModuleRun::ERROR }
     end
 
-    attempted_at Time.now
-    session_id 1
+    attempted_at { Time.now }
+    session_id { 1 }
     port { generate :port }
-    proto "tcp"
+    proto { "tcp" }
     fail_detail { generate :module_run_fail_detail }
-    status MetasploitDataModels::ModuleRun::SUCCEED
-    username "joefoo"
+    status { MetasploitDataModels::ModuleRun::SUCCEED }
+    username { "joefoo" }
     module_fullname { generate :module_run_module_fullname }
   end
 


### PR DESCRIPTION
Followed these instructions:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

active { true }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```