### PR TITLE
Fix version bumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 #MetasploitDataModels [![Build Status](https://travis-ci.org/rapid7/metasploit_data_models.png)](https://travis-ci.org/rapid7/metasploit_data_models)[![Code Climate](https://codeclimate.com/github/rapid7/metasploit_data_models.png)](https://codeclimate.com/github/rapid7/metasploit_data_models)[![Coverage Status](https://coveralls.io/repos/rapid7/metasploit_data_models/badge.png)](https://coveralls.io/r/rapid7/metasploit_data_models)[![Dependency Status](https://gemnasium.com/rapid7/metasploit_data_models.png)](https://gemnasium.com/rapid7/metasploit_data_models)[![Gem Version](https://badge.fury.io/rb/metasploit_data_models.png)](http://badge.fury.io/rb/metasploit_data_models)
 
-The database layer for Metasploit
-
+Part of Metasploit's database layer
 
 ## Purpose
 __MetasploitDataModels__ exists to do several key things:

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -1,6 +1,6 @@
 module MetasploitDataModels
   # VERSION is managed by GemRelease
-  VERSION = '3.0.3'
+  VERSION = '3.0.4'
 
   # @return [String]
   #


### PR DESCRIPTION
This should fix the automated gem building for this gem by forcing a rebuild with a version bump, followed by a non-version bump. Currently the state machine is out of sync for bumping versions, which is causing problems with automation.