### PR TITLE
restrict factory_bot to 4.x for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'coveralls', require: false  
   # supplies factories for producing model instance for specs
   # Version 4.1.0 or newer is needed to support generate calls without the 'FactoryBot.' in factory definitions syntax.
-  gem 'factory_bot'
+  gem 'factory_bot', '~>4'
   # auto-load factories from spec/factories
   gem 'factory_bot_rails'
 


### PR DESCRIPTION
Factory bot updates in the 5.x stream fail test.  Lock for now.