### PR TITLE
Add async_callback tables and migrations

### DIFF
--- a/app/models/mdm/async_callback.rb
+++ b/app/models/mdm/async_callback.rb
@@ -1,0 +1,79 @@
+# An asychronous callback that has been received by the Mettle Pingback Listener and is logged
+class Mdm::AsyncCallback < ActiveRecord::Base
+  extend ActiveSupport::Autoload
+
+  include Metasploit::Model::Search
+
+  #
+  # Associations
+  #
+
+  # @!attribute [rw] workspace
+  # {Mdm::Workspace} in which this payload was created.
+  #
+  #   @return [Mdm::Workspace]
+  belongs_to :workspace,
+             class_name: 'Mdm::Workspace',
+             inverse_of: :payloads
+
+
+  #
+  # Attributes
+  #
+
+  # @!attribute [rw] uuid
+  #   A 16-byte unique identifier for this payload. The UUID is encoded to include specific information.
+  #   See lib/msf/core/payload/uuid.rb in the https://github.com/rapid7/metasploit-framework repo.
+  #
+  #   @return [String]
+
+  # @!attribute [rw] timestamp
+  #   The Unix format timestamp when this payload called back.
+  #
+  #   @return [Integer]
+
+  # @!attribute [rw] listener_uri
+  #   Non-unique URIs (eg. "tcp://192.168.1.7:4444") which received callbacks from this payload.
+  #
+  #   @return [String]
+
+  # @!attribute [rw] target_host
+  #   The IP address (eg. "192.168.1.7" or "fe80::1") from which the callback originated, from the view of the callback listener.
+  #
+  #   @return [String]
+
+  # @!attribute [rw] target_port
+  #   The IP port (eg. "4444") from which the callback originated, from the view of the callback listener.
+  #
+  #   @return [Integer]
+
+  # @!attribute [rw] workspace_id
+  #   The ID of the workspace this payload belongs to.
+  #
+  #   @return [Integer]
+
+  #
+  # Validations
+  #
+
+  validates :workspace, :presence => true
+
+
+  #
+  # Search Attributes
+  #
+
+  search_attribute :uuid,
+                   type: :string
+
+  #
+  # Serializations
+  #
+
+  # NONE
+
+
+  public
+
+  Metasploit::Concern.run(self)
+end

--- a/app/models/mdm/async_callback.rb
+++ b/app/models/mdm/async_callback.rb
@@ -8,14 +8,6 @@ class Mdm::AsyncCallback < ActiveRecord::Base
   # Associations
   #
 
-  # @!attribute [rw] workspace
-  # {Mdm::Workspace} in which this payload callback will be logged.
-  #
-  #   @return [Mdm::Workspace]
-  belongs_to :workspace,
-             class_name: 'Mdm::Workspace',
-             inverse_of: :async_callbacks
-
 
   #
   # Attributes
@@ -47,16 +39,9 @@ class Mdm::AsyncCallback < ActiveRecord::Base
   #
   #   @return [Integer]
 
-  # @!attribute [rw] workspace_id
-  #   The ID of the workspace this payload belongs to.
-  #
-  #   @return [Integer]
-
   #
   # Validations
   #
-
-  validates :workspace, :presence => true
 
 
   #

--- a/app/models/mdm/async_callback.rb
+++ b/app/models/mdm/async_callback.rb
@@ -9,12 +9,12 @@ class Mdm::AsyncCallback < ActiveRecord::Base
   #
 
   # @!attribute [rw] workspace
-  # {Mdm::Workspace} in which this payload was created.
+  # {Mdm::Workspace} in which this payload callback will be logged.
   #
   #   @return [Mdm::Workspace]
   belongs_to :workspace,
              class_name: 'Mdm::Workspace',
-             inverse_of: :payloads
+             inverse_of: :async_callbacks
 
 
   #

--- a/app/models/mdm/workspace.rb
+++ b/app/models/mdm/workspace.rb
@@ -84,6 +84,9 @@ class Mdm::Workspace < ActiveRecord::Base
   # Payloads for this workspace.
   has_many :payloads, :class_name => 'Mdm::Payload'
 
+  # Callbacks for this workspace.
+  has_many :async_callbacks, :class_name => 'Mdm::AsyncCallback'
+
   #
   # Attributes
   #

--- a/app/models/mdm/workspace.rb
+++ b/app/models/mdm/workspace.rb
@@ -84,9 +84,6 @@ class Mdm::Workspace < ActiveRecord::Base
   # Payloads for this workspace.
   has_many :payloads, :class_name => 'Mdm::Payload'
 
-  # Callbacks for this workspace.
-  has_many :async_callbacks, :class_name => 'Mdm::AsyncCallback'
-
   #
   # Attributes
   #

--- a/db/migrate/20180308134512_create_async_callbacks.rb
+++ b/db/migrate/20180308134512_create_async_callbacks.rb
@@ -1,0 +1,14 @@
+class CreateAsyncCallbacks < ActiveRecord::Migration
+  def change
+    create_table :async_callbacks do |t|
+      t.string :uuid
+      t.integer :timestamp
+      t.string :listener_uri
+      t.string :target_host
+      t.string :target_port
+
+      t.timestamps null: false
+      t.uuid null: false
+    end
+  end
+end

--- a/db/migrate/20190308134512_create_async_callbacks.rb
+++ b/db/migrate/20190308134512_create_async_callbacks.rb
@@ -1,8 +1,8 @@
 class CreateAsyncCallbacks < ActiveRecord::Migration
   def change
     create_table :async_callbacks do |t|
-      t.string :uuid
-      t.integer :timestamp
+      t.string :uuid, :null => false
+      t.integer :timestamp, :null => false
       t.string :listener_uri
       t.string :target_host
       t.string :target_port

--- a/db/migrate/20190308134512_create_async_callbacks.rb
+++ b/db/migrate/20190308134512_create_async_callbacks.rb
@@ -7,6 +7,8 @@ class CreateAsyncCallbacks < ActiveRecord::Migration
       t.string :target_host
       t.string :target_port
 
+      t.references :workspace
+
       t.timestamps null: false
       t.uuid null: false
     end

--- a/db/migrate/20190308134512_create_async_callbacks.rb
+++ b/db/migrate/20190308134512_create_async_callbacks.rb
@@ -7,8 +7,6 @@ class CreateAsyncCallbacks < ActiveRecord::Migration
       t.string :target_host
       t.string :target_port
 
-      t.references :workspace
-
       t.timestamps null: false
       t.uuid null: false
     end

--- a/lib/mdm.rb
+++ b/lib/mdm.rb
@@ -3,6 +3,7 @@ module Mdm
   extend ActiveSupport::Autoload
 
   autoload :ApiKey
+  autoload :AsyncCallback
   autoload :Client
   autoload :Cred
   autoload :Event


### PR DESCRIPTION
### Status: Ready for testing and feedback

---

This PR adds a new Mdm model for asynchronous payloads.  It will track incoming connections for UUID-based pingback payloads, collecting the listener which received the connection and the originating IP address and port of the connection.

Note that a future PR will likely track outgoing taskings and returned data from asynchronous payloads, but that's outside the scope of this work.

## Linking ##
To link your `metasploit-framework` to this pull request, use one of the following two methods:
- **Link directly to Github:** In your `metasploit-framework` repo, edit the Gemfile and add this line to the `:development` group: `gem 'metasploit_data_models', :git => 'git@github.com:rapid7/metasploit_data_models.git', :branch => 'add_async_callback_model'`
- **Link to a local copy of the `metasploit_data_models` repo:** In your `metasploit-framework` repo, edit the Gemfile and add this line to the `:development` group: `  gem 'metasploit_data_models', :path => '/PATH_TO_GIT/metasploit_data_models'`

Now run, `bundle install`

## Verification ##
- [ ] Link your `metasploit-framework` repo's `Gemfile` to this branch.  (See 'Linking' section above.)
- [ ] Migrate your database `rake db:migrate`.  Ignore warnings about "unresolved or ambiguious specs":
```
$ rake db:migrate
WARN: Unresolved or ambigious specs during Gem::Specification.reset:
      minitest (~> 5.1)
      Available/installed versions of this gem:
      - 5.11.3
      - 5.8.4
      thor (>= 0.18.1, < 2.0)
      Available/installed versions of this gem:
      - 0.20.3
      - 0.19.1
WARN: Clearing out unresolved specs. Try 'gem cleanup <gem>'
Please report a bug if this causes problems.
$
```
- [ ] Load `msfconsole` and start `irb` or `pry`
```
$ ./msfconsole -qx 'pry'
[*] Starting Pry shell...
[*] You are in the "framework" object

[1] pry(#<Msf::Framework>)>
```
- [ ] Start by confirming that `Mdm::AsyncCallback` exists:
```
[1] pry(#<Msf::Framework>)> Mdm::AsyncCallback
=> Mdm::AsyncCallback(id: integer, uuid: string, timestamp: integer, listener_uri: string, target_host: string, target_port: string, created_at: datetime, updated_at: datetime, {:null=>false}: uuid)
```
- [ ] Confirm that the `Mdm::AsyncCallback.create()` method exists.  Calling this won't add anything to the database or do any validation.
```
[2] pry(#<Msf::Framework>)> Mdm::AsyncCallback.create()
=> #<Mdm::AsyncCallback:0x00000008cf7d00
 id: nil,
 uuid: nil,
 timestamp: nil,
 listener_uri: nil,
 target_host: nil,
 target_port: nil,
 created_at: nil,
 updated_at: nil,
 {:null=>false}: nil>
```
- [ ] Confirm that a callback object cannot be saved to the database without a valid workspace:
```
[3] pry(#<Msf::Framework>)> Mdm::AsyncCallback.create!()
ActiveRecord::RecordInvalid: Validation failed: Workspace can't be blank
from /var/lib/gems/2.3.0/gems/activerecord-4.2.11/lib/active_record/validations.rb:79:in `raise_record_invalid'
```
- [ ] Test registering a new `Mdm::AsyncCallback.create!(workspace: db.workspace)`.  It should fail because UUID and timestamp weren't specified.
- [ ] Repeat the above with a UUID and timestamp: `Mdm::AsyncCallback.create!(workspace: db.workspace, uuid: 'abcd1234efgh5687', timestamp: 1552512749)`.  You should get:
```
=> #<Mdm::AsyncCallback:0x00000006e57fa8
 id: 4,
 uuid: "abcd1234efgh5687",
 timestamp: 1552512749,
 listener_uri: nil,
 target_host: nil,
 target_port: nil,
 workspace_id: 1,
 created_at: 2019-03-13 21:32:38 UTC,
 updated_at: 2019-03-13 21:32:38 UTC,
 {:null=>false}: nil>
```
- [ ] Repeat the test, tweaking the inputs: `uuid`, `timetamp`, `listener_uri`, `target_host`, and `target_port`.  Note that only the `uuid` and `timestamp` are required.  `uuid` should be at most a 16-byte character string, `timestamp` should be an epoch-based integer, `listener_uri` should be a string (eg. `tcp://203.0.113.47:2121`), `target_host` should be an IP address or domain name, and `target_port` should be a port number.
- [ ] Verify everything was saved in the database successfully: `Mdm::AsyncCallback.all()`
