### PR TITLE
Remove reference to 'workspace' from the 'payloads' table

### DIFF
--- a/app/models/mdm/payload.rb
+++ b/app/models/mdm/payload.rb
@@ -8,14 +8,6 @@ class Mdm::Payload < ActiveRecord::Base
   # Associations
   #
 
-  # @!attribute [rw] workspace
-  # {Mdm::Workspace} in which this payload was created.
-  #
-  #   @return [Mdm::Workspace]
-  belongs_to :workspace,
-             class_name: 'Mdm::Workspace',
-             inverse_of: :payloads
-
 
   #
   # Attributes
@@ -65,11 +57,6 @@ class Mdm::Payload < ActiveRecord::Base
   #
   #   @return [String]
 
-  # @!attribute [rw] workspace_id
-  #   The ID of the workspace this payload belongs to.
-  #
-  #   @return [Integer]
-
   # @!attribute [rw] raw_payload
   #   A URL pointing to where the binary payload can be downloaded from.
   #
@@ -94,8 +81,6 @@ class Mdm::Payload < ActiveRecord::Base
   #
   # Validations
   #
-
-  validates :workspace, :presence => true
 
 
   #

--- a/app/models/mdm/workspace.rb
+++ b/app/models/mdm/workspace.rb
@@ -81,9 +81,6 @@ class Mdm::Workspace < ActiveRecord::Base
   # Sessions opened on {#hosts} in this workspace.
   has_many :sessions, :through => :hosts, :class_name => 'Mdm::Session'
 
-  # Payloads for this workspace.
-  has_many :payloads, :class_name => 'Mdm::Payload'
-
   #
   # Attributes
   #

--- a/db/migrate/20190507120211_remove_payload_workspaces.rb
+++ b/db/migrate/20190507120211_remove_payload_workspaces.rb
@@ -1,0 +1,5 @@
+class RemovePayloadWorkspaces < ActiveRecord::Migration
+  def change
+    remove_column :payloads, :workspace_id, :references
+  end
+end


### PR DESCRIPTION
# STATUS: Ready for landing

This PR, by suggestion of @bcook-r7 (AKA @busterb), removes references to `workspace` from our recent `Payload` model (#172).  When a host calls back, the `host` is part of a workspace, but the `payload` shouldn't be.

Unknown questions:
 - Does this break any other functionality (for example, in Metasploit Pro)?  Hopefully not, since the `payload` PR was only landed a month ago.
 - What am I missing?

## Linking ##
To link your `metasploit-framework` to this pull request, use one of the following two methods:
- **Link directly to Github:** In your `metasploit-framework` repo, edit the Gemfile and add this line to the `:development` group: `gem 'metasploit_data_models', :git => 'git@github.com:rapid7/metasploit_data_models.git', :branch => 'add_async_callback_model'`
- **Link to a local copy of the `metasploit_data_models` repo:** In your `metasploit-framework` repo, edit the Gemfile and add this line to the `:development` group: `  gem 'metasploit_data_models', :path => '/PATH_TO_GIT/metasploit_data_models'`

Now run, `bundle install`

## Verification ##
- [ ] Link your `metasploit-framework` repo's `Gemfile` to this branch.  (See 'Linking' section above.)
- [ ] Migrate your database using `rake db:migrate`.  Ignore warnings about "unresolved or ambiguious specs", but confirm that you see the following:
```
$ rake db:migrate
[...]
== 20190507120211 RemovePayloadWorkspaces: migrating ==========================
-- remove_column(:payloads, :workspace_id, :references)
   -> 0.0012s
== 20190507120211 RemovePayloadWorkspaces: migrated (0.0013s) =================
```
- [ ] Load `msfconsole`.
- [ ] Confirm payload generation works.
```
$ ./msfvenom -p windows/x64/meterpreter/bind_tcp -f exe -o deleteme.exe
$ ./msfconsole -qx 'use payload/windows/x64/meterpreter/bind_tcp; generate -f exe -o delete.exe; exit'
```
- [ ] Perform additional testing, maybe in Pro?