### PR TITLE
update error messages for rails 5

### DIFF
--- a/app/models/mdm/api_key.rb
+++ b/app/models/mdm/api_key.rb
@@ -53,7 +53,7 @@ class Mdm::ApiKey < ApplicationRecord
     license = License.get
 
     if license and not license.supports_api?
-      errors[:license] = " - this product does not support API access"
+      errors.add :license, " - this product does not support API access"
     end
   end
 

--- a/app/validators/ip_format_validator.rb
+++ b/app/validators/ip_format_validator.rb
@@ -6,7 +6,7 @@ class IpFormatValidator < ActiveModel::EachValidator
   #
   # @return [void]
   def validate_each(object, attribute, value)
-    error_message_block = lambda{ object.errors[attribute] << " must be a valid IPv4 or IPv6 address" }
+    error_message_block = lambda{ object.errors.add attribute, " must be a valid IPv4 or IPv6 address" }
     begin
       if value.is_a? IPAddr
         potential_ip = value.dup

--- a/app/validators/parameters_validator.rb
+++ b/app/validators/parameters_validator.rb
@@ -33,7 +33,7 @@ class ParametersValidator < ActiveModel::EachValidator
                 :index => index
             )
 
-            record.errors[attribute] << length_error
+            record.errors.add attribute, length_error
           else
             parameter_name = element.first
 
@@ -44,7 +44,7 @@ class ParametersValidator < ActiveModel::EachValidator
                     :index => index,
                     :prefix => "has blank parameter name"
                 )
-                record.errors[attribute] << error
+                record.errors.add attribute, error
               end
             else
               error = error_at(
@@ -52,7 +52,7 @@ class ParametersValidator < ActiveModel::EachValidator
                   :index => index,
                   :prefix => "has non-String parameter name (#{parameter_name.inspect})"
               )
-              record.errors[attribute] << error
+              record.errors.add attribute, error
             end
 
             parameter_value = element.second
@@ -63,7 +63,7 @@ class ParametersValidator < ActiveModel::EachValidator
                   :index => index,
                   :prefix => "has non-String parameter value (#{parameter_value.inspect})"
               )
-              record.errors[attribute] << error
+              record.errors.add attribute, error
             end
           end
         else
@@ -72,11 +72,11 @@ class ParametersValidator < ActiveModel::EachValidator
               :index => index,
               :prefix => 'has non-Array'
           )
-          record.errors[attribute] << error
+          record.errors.add attribute, error
         end
       end
     else
-      record.errors[attribute] << "is not an Array.  #{TYPE_SIGNATURE_SENTENCE}"
+      record.errors.add attribute, "is not an Array.  #{TYPE_SIGNATURE_SENTENCE}"
     end
   end
 


### PR DESCRIPTION
While evaluating code in metasploit for Rails 5 I missed that error syntax for the models changed.

Update convert direct assignment to call to `.add` [errors](https://api.rubyonrails.org/classes/ActiveModel/Errors.html).