### PR TITLE
remove deprecation warnings

### DIFF
--- a/app/models/metasploit_data_models/search/visitor/where.rb
+++ b/app/models/metasploit_data_models/search/visitor/where.rb
@@ -91,7 +91,7 @@ class MetasploitDataModels::Search::Visitor::Where
   visit 'MetasploitDataModels::Search::Operation::Port::Range' do |range_operation|
     attribute = attribute_visitor.visit range_operation.operator
 
-    attribute.in(range_operation.value)
+    attribute.between(range_operation.value)
   end
 
   #

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = %w{app/models app/validators lib}
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.4'
 
   # ---- Dependencies ----
   # documentation

--- a/spec/app/models/metasploit_data_models/search/visitor/where_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/visitor/where_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe MetasploitDataModels::Search::Visitor::Where, type: :model do
         attribute = double('Visited Operator')
         allow(visitor.attribute_visitor).to receive(:visit).with(operator).and_return(attribute)
 
-        expect(attribute).to receive(:in).with(range)
+        expect(attribute).to receive(:between).with(range)
 
         visit
       end


### PR DESCRIPTION
* migrate from `in` to `between` per warning for Rails 6 deprecation
* set min ruby 2.4