### PR TITLE
remove duplicate contraint

### DIFF
--- a/db/migrate/20190308134512_create_async_callbacks.rb
+++ b/db/migrate/20190308134512_create_async_callbacks.rb
@@ -8,7 +8,6 @@ class CreateAsyncCallbacks < ActiveRecord::Migration[4.2]
       t.string :target_port
 
       t.timestamps null: false
-      t.uuid null: false
     end
   end
 end

--- a/spec/app/models/metasploit_data_models/ip_address/v4/segment/single_spec.rb
+++ b/spec/app/models/metasploit_data_models/ip_address/v4/segment/single_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Segment::Single, type: :mode
   end
 
   context '#to_s' do
-    subject(:to_s) {
+    subject(:call_to_s) {
       single.to_s
     }
 
@@ -256,7 +256,7 @@ RSpec.describe MetasploitDataModels::IPAddress::V4::Segment::Single, type: :mode
     it 'delegates to #value' do
       expect(value).to receive(:to_s)
 
-      to_s
+      call_to_s
     end
   end
 


### PR DESCRIPTION
The constraint on `:uuid` is in the column define already

This was noted while doing some exploratory testing for Rails 6 migration support.