### PR TITLE
update to Rails 6.x compatible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,6 @@ group :development, :test do
   # bound to 0.20 for Activerecord 4.2.8 deprecation warnings:
   # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
   gem 'pg'
-
-  gem 'pry'
 end
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ different `on_load` name, which is just the class name converted to an underscor
 
     require 'metasploit_data_models/engine'
 
+`ArelHelper` classes must also be included in your applications `app/models/application_record.rb` class:
+
+    class ApplicationRecord < ActiveRecord::Base
+      self.abstract_class = true
+      include ArelHelpers::ArelTable
+      include ArelHelpers::JoinAssociation
+    end
+
 ### Metasploit Framework
 
 In Metasploit Framework, `MetasploitDataModels::Engine` is loaded, but the data models are only if the user wants to use

--- a/app/models/metasploit_data_models/ip_address/v4/segment/nmap/list.rb
+++ b/app/models/metasploit_data_models/ip_address/v4/segment/nmap/list.rb
@@ -12,7 +12,7 @@ class MetasploitDataModels::IPAddress::V4::Segment::Nmap::List < Metasploit::Mod
   # Either an individual {MetasploitDataModels::IPAddress::V4::Segment::Single segment number} or a
   # {MetasploitDataModels::IPAddress::V4::Segment::Nmap::Range segment range}.
   RANGE_OR_NUMBER_REGEXP = %r{
-      (?<range>#{parent::Range.regexp})
+      (?<range>#{module_parent::Range.regexp})
       |
       # range first because it contains a segment and if the range isn't first only the first part of the range will
       # match.

--- a/app/models/metasploit_data_models/search/visitor/relation.rb
+++ b/app/models/metasploit_data_models/search/visitor/relation.rb
@@ -67,7 +67,7 @@ class MetasploitDataModels::Search::Visitor::Relation < Metasploit::Model::Base
   # @return [Hash{Symbol => Class}]
   def self.visitor_class_by_relation_method
     @relation_method_by_visitor_class ||= RELATION_METHODS.each_with_object({}) { |relation_method, relation_method_by_visitor_class|
-      visitor_class_name = "#{parent.name}::#{relation_method.to_s.camelize}"
+      visitor_class_name = "#{module_parent.name}::#{relation_method.to_s.camelize}"
       visitor_class = visitor_class_name.constantize
 
       relation_method_by_visitor_class[relation_method] = visitor_class

--- a/config/initializers/arel_helper.rb
+++ b/config/initializers/arel_helper.rb
@@ -1,5 +1,0 @@
-# Including arel-helpers in all active record models.
-# https://github.com/camertron/arel-helpers
-
-ApplicationRecord.send(:include, ArelHelpers::ArelTable)
-ApplicationRecord.send(:include, ArelHelpers::JoinAssociation)

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -1,6 +1,6 @@
 module MetasploitDataModels
   # VERSION is managed by GemRelease
-  VERSION = '4.1.5'
+  VERSION = '5.0.0'
 
   # @return [String]
   #

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -33,11 +33,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
 
 
-  s.add_runtime_dependency 'activerecord', '~>5.2.2'
-  s.add_runtime_dependency 'activesupport', '~>5.2.2'
+  s.add_runtime_dependency 'activerecord', '~>6.0'
+  s.add_runtime_dependency 'activesupport', '~>6.0'
   s.add_runtime_dependency 'metasploit-concern'
   s.add_runtime_dependency 'metasploit-model', '>=3.1'
-  s.add_runtime_dependency 'railties', '~>5.2.2'
+  s.add_runtime_dependency 'railties', '~>6.0'
   s.add_runtime_dependency 'webrick'
 
   # os fingerprinting

--- a/spec/app/models/metasploit_data_models/search/visitor/attribute_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/visitor/attribute_spec.rb
@@ -28,7 +28,11 @@ RSpec.describe MetasploitDataModels::Search::Visitor::Attribute, type: :model do
           end
 
           it "should be #{node_class}#attribute" do
-            expect(name).to eq(node.attribute)
+            if node.attribute.instance_of? Symbol
+              expect(name.to_s).to eq(node.attribute.to_s)
+            else
+              expect(name).to eq(node.attribute)
+            end
           end
         end
 

--- a/spec/dummy/app/models/application_record.rb
+++ b/spec/dummy/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+  include ArelHelpers::ArelTable
+  include ArelHelpers::JoinAssociation
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -56,6 +56,8 @@ module Dummy
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    config.autoloader = :zeitwerk
   end
 end
 

--- a/spec/dummy/config/storage.yml
+++ b/spec/dummy/config/storage.yml
@@ -1,0 +1,7 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -5,26 +5,11 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
 SET default_tablespace = '';
-
-SET default_with_oids = false;
 
 --
 -- Name: api_keys; Type: TABLE; Schema: public; Owner: -
@@ -64,8 +49,8 @@ ALTER SEQUENCE public.api_keys_id_seq OWNED BY public.api_keys.id;
 CREATE TABLE public.ar_internal_metadata (
     key character varying NOT NULL,
     value character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 


### PR DESCRIPTION
Allow usage with Rails 6.x

Documents the `ArelHelper` classes that must be included in `ApplicationRecord` for any project will utilize the models in this Rails Engine.

Depends on https://github.com/rapid7/metasploit-model/pull/57 & https://github.com/rapid7/metasploit-concern/pull/33 land and release.