### PR TITLE
Add ruby 3.0 to CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -52,12 +52,12 @@ jobs:
 
       - name: Setup bundler
         run: |
-          gem install bundler
+          gem install bundler:2.1.4
 
       - name: Bundle install
         run: |
           bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundle _2.1.4_ install --jobs 4 --retry 3
 
       - name: Test
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,7 +30,10 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
+          - 2.5
+          - 2.6
           - 2.7
+          - 3.0
 
     env:
       RAILS_ENV: test

--- a/db/migrate/20140905031549_add_detected_arch_to_host.rb
+++ b/db/migrate/20140905031549_add_detected_arch_to_host.rb
@@ -1,5 +1,5 @@
 class AddDetectedArchToHost < ActiveRecord::Migration[4.2]
   def change
-    add_column :hosts, :detected_arch, :string, { :null => true }
+    add_column :hosts, :detected_arch, :string, :null => true
   end
 end

--- a/spec/app/models/metasploit_data_models/search/operation/range_spec.rb
+++ b/spec/app/models/metasploit_data_models/search/operation/range_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe MetasploitDataModels::Search::Operation::Range, type: :model do
 
       context '#ordered' do
         let(:error) {
-          I18n.translate!('metasploit.model.errors.models.metasploit_data_models/search/operation/range.attributes.value.order', error_attributes)
+          I18n.translate!('metasploit.model.errors.models.metasploit_data_models/search/operation/range.attributes.value.order', **error_attributes)
         }
 
         context 'with Range' do


### PR DESCRIPTION
Adding test coverage for Ruby 3.0

Also pinning the bundler version to 2.1.4 until this issue rubygems/rubygems#4539 has been addressed