### PR TITLE
Update Ubuntu version & Ruby Setup action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     timeout-minutes: 40
 
     services:
@@ -46,18 +46,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Setup bundler
-        run: |
-          gem install bundler:2.1.4
-
-      - name: Bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle _2.1.4_ install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Test
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   # auto-load factories from spec/factories
   gem 'factory_bot_rails'
 
-  gem 'rails'
+  gem 'rails', '~> 6.0'
   # Used to create fake data
   gem "faker"
 

--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ else
 end
 
 if print_without
-  puts "Bundle currently installed '--without #{Bundler.settings.without.join(' ')}'."
+  puts "Bundle currently installed '--without #{Bundler.settings[:without].join(' ')}'."
   puts "To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or " \
        "`rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`"
 end


### PR DESCRIPTION
This PR updates the Github Workflow to use Ubuntu 18.04 rather than the deprecated 16.04.
It also uses the updated ruby setup tool [ruby/setup-ruby@v1](https://github.com/ruby/setup-ruby) instead of the older [actions/setup-ruby@v1](https://github.com/actions/setup-ruby).

It also fixes the current CI warning:

> Lint : .github#L1The ubuntu-16.04 environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details see https://github.com/actions/virtual-environments/issues/3287