### PR TITLE
Add indices to notes table to speed up lookups

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -4,7 +4,7 @@
 
 ENGINE_ROOT = File.expand_path('..', __dir__)
 ENGINE_PATH = File.expand_path('../lib/metasploit_data_models/engine', __dir__)
-APP_PATH = File.expand_path('../test/dummy/config/application', __dir__)
+APP_PATH = File.expand_path('../spec/dummy/config/application', __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)

--- a/db/migrate/20211011125435_add_indices_to_notes.rb
+++ b/db/migrate/20211011125435_add_indices_to_notes.rb
@@ -1,0 +1,6 @@
+class AddIndicesToNotes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :notes, :host_id
+    add_index :notes, :service_id
+  end
+end


### PR DESCRIPTION
Adds a couple indices to the notes table to speed up lookups which were a limiting factor in the speed of `db_import`