### PR TITLE
Add support for rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in metasploit_data_models.gemspec
 gemspec
 
-gem 'metasploit-concern', git: 'https://github.com/jmartin-r7/metasploit-concern', branch: 'add-support-for-rails-7'
-
-
 group :development do
   #gem 'metasploit-erd'
   # embed ERDs on index, namespace Module and Class<ApplicationRecord> pages

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in metasploit_data_models.gemspec
 gemspec
 
+gem 'metasploit-concern', git: 'https://github.com/jmartin-r7/metasploit-concern', branch: 'add-support-for-rails-7'
+
+
 group :development do
   #gem 'metasploit-erd'
   # embed ERDs on index, namespace Module and Class<ApplicationRecord> pages
@@ -19,7 +22,7 @@ group :development, :test do
   # auto-load factories from spec/factories
   gem 'factory_bot_rails'
 
-  gem 'rails', '~> 6.0'
+  gem 'rails'
   gem 'net-smtp', require: false
 
   # Used to create fake data

--- a/app/models/mdm/host_tag.rb
+++ b/app/models/mdm/host_tag.rb
@@ -38,7 +38,9 @@ class Mdm::HostTag < ApplicationRecord
   # @see http://stackoverflow.com/a/11694704
   # @return [void]
   def destroy_orphan_tag
-    tag.destroy_if_orphaned
+    # ensure fresh load of tag record
+    # in theory this will always return one result safe navigation is just "extra"
+    Mdm::Tag.where(id: tag.id).first&.destroy_if_orphaned
   end
 
   # switch back to public for load hooks

--- a/app/models/mdm/tag.rb
+++ b/app/models/mdm/tag.rb
@@ -100,7 +100,8 @@ class Mdm::Tag < ApplicationRecord
   # @return [void]
   def destroy_if_orphaned
     self.class.transaction do
-      if hosts_tags.empty?
+      # call `.count` to avoid serialization of any Mdm::HostTag that may exist
+      if hosts_tags.count == 0
         destroy
       end
     end

--- a/app/models/mdm/workspace.rb
+++ b/app/models/mdm/workspace.rb
@@ -18,7 +18,7 @@ class Mdm::Workspace < ApplicationRecord
 
   # Automatic exploitation match sets generated against {#hosts} and {#services} in this workspace.
   has_many :automatic_exploitation_match_sets,
-           class_name: 'MetasploitDataModels::AutomaticExploitation:MatchSet',
+           class_name: 'MetasploitDataModels::AutomaticExploitation::MatchSet',
            inverse_of: :workspace
 
 

--- a/lib/metasploit_data_models/engine.rb
+++ b/lib/metasploit_data_models/engine.rb
@@ -5,7 +5,6 @@ require 'rails'
 class MetasploitDataModels::Engine < Rails::Engine
   # @see http://viget.com/extend/rails-engine-testing-with-rspec-capybara-and-factorygirl
   config.generators do |g|
-    g.assets false
     g.fixture_replacement :factory_bot, :dir => 'spec/factories'
     g.helper false
     g.test_framework :rspec, :fixture => false

--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -1,6 +1,6 @@
 module MetasploitDataModels
   # VERSION is managed by GemRelease
-  VERSION = '5.0.7'
+  VERSION = '6.0.0'
 
   # @return [String]
   #

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -33,11 +33,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
 
 
-  s.add_runtime_dependency 'activerecord', '~>6.0'
-  s.add_runtime_dependency 'activesupport', '~>6.0'
+  s.add_runtime_dependency 'activerecord', '~>7.0'
+  s.add_runtime_dependency 'activesupport', '~>7.0'
   s.add_runtime_dependency 'metasploit-concern'
   s.add_runtime_dependency 'metasploit-model', '>=3.1'
-  s.add_runtime_dependency 'railties', '~>6.0'
+  s.add_runtime_dependency 'railties', '~>7.0'
   s.add_runtime_dependency 'webrick'
 
   # os fingerprinting

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = %w{app/models app/validators lib}
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.7'
 
   # ---- Dependencies ----
   # documentation

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -57,6 +57,8 @@ module Dummy
     config.active_record.belongs_to_required_by_default = true
 
     config.autoloader = :zeitwerk
+
+    ActiveRecord.legacy_connection_handling = false
   end
 end
 

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -56,12 +56,6 @@ module Dummy
     # 5.x change to belongs_to
     config.active_record.belongs_to_required_by_default = true
 
-    # Enable the asset pipeline
-    config.assets.enabled = false
-
-    # Version of your assets, change this if you want to expire all your assets
-    config.assets.version = '1.0'
-
     config.autoloader = :zeitwerk
   end
 end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -22,16 +22,6 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
-
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -22,18 +22,6 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_assets = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
-
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
-  # Generate digests for assets URLs.
-  config.assets.digest = true
-
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )


### PR DESCRIPTION
Updates to support Rails 7

* adjusts a caching issue around an `after_destroy` call that can cause failure to remove an orphaned tag.
* Fixes an typo is a `Workspace` relationship
* Remove configuration references to `assets` not used in the gem
* Updates test `ActiveRecord` connection handling to remove testing warning.