### PR TITLE
relax loot model to remove host requirement

### DIFF
--- a/app/models/mdm/loot.rb
+++ b/app/models/mdm/loot.rb
@@ -31,6 +31,7 @@ class Mdm::Loot < ApplicationRecord
   #   @return [Mdm::Host]
   belongs_to :host,
              class_name: 'Mdm::Host',
+             optional: true, # allow for manually stored loot
              inverse_of: :loots
 
   # @!attribute [rw] module_run

--- a/spec/app/models/mdm/loot_spec.rb
+++ b/spec/app/models/mdm/loot_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Mdm::Loot, type: :model do
   context 'associations' do
     it { is_expected.to belong_to(:workspace).class_name('Mdm::Workspace') }
     it { is_expected.to belong_to(:service).optional.class_name('Mdm::Service') }
-    it { is_expected.to belong_to(:host).class_name('Mdm::Host') }
+    it { is_expected.to belong_to(:host).optional.class_name('Mdm::Host') }
     it { is_expected.to belong_to(:module_run).optional.class_name('MetasploitDataModels::ModuleRun') }
   end
 


### PR DESCRIPTION
Rails 7 validation expands on `belongs_to` validation change from #193

* loot is not require to associated directly to a host
* loot must attach attach to a workspace