### PR TITLE
Fix rails 7.2 errors and warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :development, :test do
   # auto-load factories from spec/factories
   gem 'factory_bot_rails'
 
-  gem 'rails'
+  gem 'rails', '~>  7.0'
   gem 'net-smtp', require: false
 
   # Used to create fake data

--- a/app/models/mdm/event.rb
+++ b/app/models/mdm/event.rb
@@ -72,7 +72,7 @@ class Mdm::Event < ApplicationRecord
   # {#name}-specific information about this event.
   #
   # @return [Hash]
-  serialize :info, MetasploitDataModels::Base64Serializer.new
+  serialize :info, coder: MetasploitDataModels::Base64Serializer.new
 
   #
   # Validations

--- a/app/models/mdm/listener.rb
+++ b/app/models/mdm/listener.rb
@@ -69,7 +69,7 @@ class Mdm::Listener < ApplicationRecord
   # Options used to spawn this listener.
   #
   # @return [Hash]
-  serialize :options, MetasploitDataModels::Base64Serializer.new
+  serialize :options, coder: MetasploitDataModels::Base64Serializer.new
 
   #
   # Validations

--- a/app/models/mdm/loot.rb
+++ b/app/models/mdm/loot.rb
@@ -140,7 +140,7 @@ class Mdm::Loot < ApplicationRecord
   # Serializations
   #
 
-  serialize :data, MetasploitDataModels::Base64Serializer.new
+  serialize :data, coder: MetasploitDataModels::Base64Serializer.new
 
   private
 

--- a/app/models/mdm/macro.rb
+++ b/app/models/mdm/macro.rb
@@ -39,12 +39,12 @@ class Mdm::Macro < ApplicationRecord
   #
   # @return [Array<Hash{Symbol=>Object}>] Array of action hashes.  Each action hash is have key :module with value
   #   of an {Mdm::Module::Detail#fullname} and and key :options with value of options used to the run the module.
-  serialize :actions, MetasploitDataModels::Base64Serializer.new
+  serialize :actions, coder: MetasploitDataModels::Base64Serializer.new
 
   # Preference for this macro, shared across all actions.
   #
   # @return [Hash]
-  serialize :prefs, MetasploitDataModels::Base64Serializer.new
+  serialize :prefs, coder: MetasploitDataModels::Base64Serializer.new
 
   # The maximum number of seconds that this macro is allowed to run.
   #

--- a/app/models/mdm/nexpose_console.rb
+++ b/app/models/mdm/nexpose_console.rb
@@ -89,7 +89,7 @@ class Mdm::NexposeConsole < ApplicationRecord
   #   List of sites known to Nexpose.
   #
   #   @return [Array<String>] Array of site names.
-  serialize :cached_sites, MetasploitDataModels::Base64Serializer.new
+  serialize :cached_sites, coder: MetasploitDataModels::Base64Serializer.new
 
   #
   # Validations

--- a/app/models/mdm/note.rb
+++ b/app/models/mdm/note.rb
@@ -107,7 +107,7 @@ class Mdm::Note < ApplicationRecord
   # Serializations
   #
 
-  serialize :data, ::MetasploitDataModels::Base64Serializer.new
+  serialize :data, coder: ::MetasploitDataModels::Base64Serializer.new
 
   private
 

--- a/app/models/mdm/profile.rb
+++ b/app/models/mdm/profile.rb
@@ -38,7 +38,7 @@ class Mdm::Profile < ApplicationRecord
   # Global settings.
   #
   # @return [Hash]
-  serialize :settings, MetasploitDataModels::Base64Serializer.new
+  serialize :settings, coder: MetasploitDataModels::Base64Serializer.new
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/mdm/session.rb
+++ b/app/models/mdm/session.rb
@@ -172,7 +172,7 @@ class Mdm::Session < ApplicationRecord
   # Serializations
   #
 
-  serialize :datastore, ::MetasploitDataModels::Base64Serializer.new
+  serialize :datastore, coder: ::MetasploitDataModels::Base64Serializer.new
 
   # Returns whether the session can be upgraded to a meterpreter session from a shell session on Windows.
   #

--- a/app/models/mdm/task.rb
+++ b/app/models/mdm/task.rb
@@ -130,17 +130,17 @@ class Mdm::Task < ApplicationRecord
   # Options passed to `#module`.
   #
   # @return [Hash]
-  serialize :options, MetasploitDataModels::Base64Serializer.new
+  serialize :options, coder: MetasploitDataModels::Base64Serializer.new
 
   # Result of task running.
   #
   # @return [Hash]
-  serialize :result, MetasploitDataModels::Base64Serializer.new
+  serialize :result, coder: MetasploitDataModels::Base64Serializer.new
 
   # Settings used to configure this task outside of the {#options module options}.
   #
   # @return [Hash]
-  serialize :settings, MetasploitDataModels::Base64Serializer.new
+  serialize :settings, coder: MetasploitDataModels::Base64Serializer.new
 
   #
   # Instance Methods

--- a/app/models/mdm/user.rb
+++ b/app/models/mdm/user.rb
@@ -109,7 +109,7 @@ class Mdm::User < ApplicationRecord
   # Hash of user preferences
   #
   # @return [Hash]
-  serialize :prefs, MetasploitDataModels::Base64Serializer.new
+  serialize :prefs, coder: MetasploitDataModels::Base64Serializer.new
 
   # @!attribute time_zone
   #   User's preferred time zone.

--- a/app/models/mdm/web_form.rb
+++ b/app/models/mdm/web_form.rb
@@ -46,7 +46,7 @@ class Mdm::WebForm < ApplicationRecord
   # Parameters submitted in this form.
   #
   # @return [Array<Array(String, String)>>]
-  serialize :params, MetasploitDataModels::Base64Serializer.new
+  serialize :params, coder: MetasploitDataModels::Base64Serializer.new
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/mdm/web_page.rb
+++ b/app/models/mdm/web_page.rb
@@ -81,12 +81,12 @@ class Mdm::WebPage < ApplicationRecord
   # Headers sent from server.
   #
   # @return [Hash{String => String}]
-  serialize :headers, MetasploitDataModels::Base64Serializer.new
+  serialize :headers, coder: MetasploitDataModels::Base64Serializer.new
 
   # Cookies sent from server.
   #
   # @return [Hash{String => String}]
-  serialize :cookie
+  serialize :cookie, coder: MetasploitDataModels::Base64Serializer.new
   Metasploit::Concern.run(self)
 end
 

--- a/app/models/mdm/web_site.rb
+++ b/app/models/mdm/web_site.rb
@@ -60,7 +60,7 @@ class Mdm::WebSite < ApplicationRecord
 
   # @!attribute [rw] options
   #   @todo Determine format and purpose of Mdm::WebSite#options.
-  serialize :options, ::MetasploitDataModels::Base64Serializer.new
+  serialize :options, coder: ::MetasploitDataModels::Base64Serializer.new
 
   #
   # Instance Methods

--- a/app/models/mdm/web_vuln.rb
+++ b/app/models/mdm/web_vuln.rb
@@ -141,7 +141,7 @@ class Mdm::WebVuln < ApplicationRecord
   #   Parameters sent as part of request
   #
   #   @return [Array<Array(String, String)>] Array of parameter key value pairs
-  serialize :params, MetasploitDataModels::Base64Serializer.new(:default => DEFAULT_PARAMS)
+  serialize :params, coder: MetasploitDataModels::Base64Serializer.new(:default => DEFAULT_PARAMS)
 
   #
   # Methods

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -57,8 +57,6 @@ module Dummy
     config.active_record.belongs_to_required_by_default = true
 
     config.autoloader = :zeitwerk
-
-    ActiveRecord.legacy_connection_handling = false
   end
 end
 


### PR DESCRIPTION
`metasploit_data_models` does not have a `Gemfile.lock` so a fresh checkout will install Rails 7.2 - which breaks this repository. This pull request updates the repository to work with Rails 7.2