### PR TITLE
Upversion Github actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,7 +66,7 @@ jobs:
         run: sudo apt-get install libpcap-dev graphviz
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR upversions the github actions, from `actions/checkout@v2` to `actions/checkout@v4`.

v2 ran on Node.js 16, which is deprecated by Github. Runs using v2 have a deprecation warning, as can be viewed at the bottom of https://github.com/rapid7/metasploit_data_models/actions/runs/7815381726

v4 runs on Node.js 20, which clears these deprecation warnings. An example of the warnings being cleared can be found at https://github.com/KanchiMoe/metasploit_data_models/actions/runs/9063988462

More information on this can be found at https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.