### PR TITLE
Update Rails 7.1 support

### DIFF
--- a/app/models/mdm/event.rb
+++ b/app/models/mdm/event.rb
@@ -72,7 +72,11 @@ class Mdm::Event < ApplicationRecord
   # {#name}-specific information about this event.
   #
   # @return [Hash]
-  serialize :info, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :info, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :info, MetasploitDataModels::Base64Serializer.new
+  end
 
   #
   # Validations

--- a/app/models/mdm/listener.rb
+++ b/app/models/mdm/listener.rb
@@ -69,7 +69,11 @@ class Mdm::Listener < ApplicationRecord
   # Options used to spawn this listener.
   #
   # @return [Hash]
-  serialize :options, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :options, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :options, MetasploitDataModels::Base64Serializer.new
+  end
 
   #
   # Validations

--- a/app/models/mdm/loot.rb
+++ b/app/models/mdm/loot.rb
@@ -140,7 +140,11 @@ class Mdm::Loot < ApplicationRecord
   # Serializations
   #
 
-  serialize :data, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :data, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :data, MetasploitDataModels::Base64Serializer.new
+  end
 
   private
 

--- a/app/models/mdm/macro.rb
+++ b/app/models/mdm/macro.rb
@@ -39,12 +39,20 @@ class Mdm::Macro < ApplicationRecord
   #
   # @return [Array<Hash{Symbol=>Object}>] Array of action hashes.  Each action hash is have key :module with value
   #   of an {Mdm::Module::Detail#fullname} and and key :options with value of options used to the run the module.
-  serialize :actions, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :actions, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :actions, MetasploitDataModels::Base64Serializer.new
+  end
 
   # Preference for this macro, shared across all actions.
   #
   # @return [Hash]
-  serialize :prefs, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :prefs, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :prefs, MetasploitDataModels::Base64Serializer.new
+  end
 
   # The maximum number of seconds that this macro is allowed to run.
   #

--- a/app/models/mdm/nexpose_console.rb
+++ b/app/models/mdm/nexpose_console.rb
@@ -89,7 +89,11 @@ class Mdm::NexposeConsole < ApplicationRecord
   #   List of sites known to Nexpose.
   #
   #   @return [Array<String>] Array of site names.
-  serialize :cached_sites, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :cached_sites, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :cached_sites, MetasploitDataModels::Base64Serializer.new
+  end
 
   #
   # Validations
@@ -113,7 +117,7 @@ class Mdm::NexposeConsole < ApplicationRecord
   #
   # @return [void]
   def strip_protocol
-    self.address.gsub!(/^http(s)*:\/\//i,'') unless self.address.nil?  
+    self.address.gsub!(/^http(s)*:\/\//i,'') unless self.address.nil?
   end
 
   Metasploit::Concern.run(self)

--- a/app/models/mdm/note.rb
+++ b/app/models/mdm/note.rb
@@ -1,6 +1,6 @@
 # Data gathered or derived from the {#host} or {#service} such as its {#ntype fingerprint}.
 class Mdm::Note < ApplicationRecord
-  
+
   #
   # Associations
   #
@@ -107,7 +107,11 @@ class Mdm::Note < ApplicationRecord
   # Serializations
   #
 
-  serialize :data, coder: ::MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :data, coder: ::MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :data, ::MetasploitDataModels::Base64Serializer.new
+  end
 
   private
 

--- a/app/models/mdm/profile.rb
+++ b/app/models/mdm/profile.rb
@@ -38,7 +38,11 @@ class Mdm::Profile < ApplicationRecord
   # Global settings.
   #
   # @return [Hash]
-  serialize :settings, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :settings, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :settings, MetasploitDataModels::Base64Serializer.new
+  end
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/mdm/session.rb
+++ b/app/models/mdm/session.rb
@@ -1,7 +1,7 @@
 # A session opened on a {#host} using an {#via_exploit exploit} and controlled through a {#via_payload payload} to
 # connect back to the local host using meterpreter or a cmd shell.
 class Mdm::Session < ApplicationRecord
-  
+
   #
   # Associations
   #
@@ -172,7 +172,11 @@ class Mdm::Session < ApplicationRecord
   # Serializations
   #
 
-  serialize :datastore, coder: ::MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :datastore, coder: ::MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :datastore, ::MetasploitDataModels::Base64Serializer.new
+  end
 
   # Returns whether the session can be upgraded to a meterpreter session from a shell session on Windows.
   #

--- a/app/models/mdm/task.rb
+++ b/app/models/mdm/task.rb
@@ -130,17 +130,29 @@ class Mdm::Task < ApplicationRecord
   # Options passed to `#module`.
   #
   # @return [Hash]
-  serialize :options, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :options, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :options, MetasploitDataModels::Base64Serializer.new
+  end
 
   # Result of task running.
   #
   # @return [Hash]
-  serialize :result, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :result, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :result, MetasploitDataModels::Base64Serializer.new
+  end
 
   # Settings used to configure this task outside of the {#options module options}.
   #
   # @return [Hash]
-  serialize :settings, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :settings, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :settings, MetasploitDataModels::Base64Serializer.new
+  end
 
   #
   # Instance Methods

--- a/app/models/mdm/user.rb
+++ b/app/models/mdm/user.rb
@@ -1,7 +1,7 @@
 # A user of metasploit-framework or metasploit-pro.
 class Mdm::User < ApplicationRecord
   extend MetasploitDataModels::SerializedPrefs
-  
+
   #
   # Associations
   #
@@ -109,7 +109,11 @@ class Mdm::User < ApplicationRecord
   # Hash of user preferences
   #
   # @return [Hash]
-  serialize :prefs, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :prefs, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :prefs, MetasploitDataModels::Base64Serializer.new
+  end
 
   # @!attribute time_zone
   #   User's preferred time zone.

--- a/app/models/mdm/web_form.rb
+++ b/app/models/mdm/web_form.rb
@@ -1,6 +1,6 @@
 # A filled-in form on a {#web_site}.
 class Mdm::WebForm < ApplicationRecord
-  
+
   #
   # Associations
   #
@@ -46,7 +46,11 @@ class Mdm::WebForm < ApplicationRecord
   # Parameters submitted in this form.
   #
   # @return [Array<Array(String, String)>>]
-  serialize :params, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :params, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :params, MetasploitDataModels::Base64Serializer.new
+  end
 
   Metasploit::Concern.run(self)
 end

--- a/app/models/mdm/web_page.rb
+++ b/app/models/mdm/web_page.rb
@@ -81,12 +81,20 @@ class Mdm::WebPage < ApplicationRecord
   # Headers sent from server.
   #
   # @return [Hash{String => String}]
-  serialize :headers, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :headers, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :headers, MetasploitDataModels::Base64Serializer.new
+  end
 
   # Cookies sent from server.
   #
   # @return [Hash{String => String}]
-  serialize :cookie, coder: MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :cookie, coder: MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :cookie, MetasploitDataModels::Base64Serializer.new
+  end
   Metasploit::Concern.run(self)
 end
 

--- a/app/models/mdm/web_site.rb
+++ b/app/models/mdm/web_site.rb
@@ -1,6 +1,6 @@
 # A Web Site running on a {#service}.
 class Mdm::WebSite < ApplicationRecord
-  
+
   #
   # Associations
   #
@@ -60,7 +60,11 @@ class Mdm::WebSite < ApplicationRecord
 
   # @!attribute [rw] options
   #   @todo Determine format and purpose of Mdm::WebSite#options.
-  serialize :options, coder: ::MetasploitDataModels::Base64Serializer.new
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :options, coder: ::MetasploitDataModels::Base64Serializer.new
+  else
+    serialize :options, ::MetasploitDataModels::Base64Serializer.new
+  end
 
   #
   # Instance Methods

--- a/app/models/mdm/web_vuln.rb
+++ b/app/models/mdm/web_vuln.rb
@@ -11,7 +11,7 @@
 #     end
 #   end
 class Mdm::WebVuln < ApplicationRecord
-  
+
   #
   # CONSTANTS
   #
@@ -141,7 +141,11 @@ class Mdm::WebVuln < ApplicationRecord
   #   Parameters sent as part of request
   #
   #   @return [Array<Array(String, String)>] Array of parameter key value pairs
-  serialize :params, coder: MetasploitDataModels::Base64Serializer.new(:default => DEFAULT_PARAMS)
+  if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
+    serialize :params, coder: MetasploitDataModels::Base64Serializer.new(:default => DEFAULT_PARAMS)
+  else
+    serialize :params, MetasploitDataModels::Base64Serializer.new(:default => DEFAULT_PARAMS)
+  end
 
   #
   # Methods


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit_data_models/pull/204 which added Rails 7.1 support - but it was never released to rubygems

Updates this repo to align with the convention used in https://github.com/rapid7/metasploit-credential/pull/180