### PR TITLE
Add coerce param to Base64Serializer

### DIFF
--- a/app/models/mdm/event.rb
+++ b/app/models/mdm/event.rb
@@ -73,9 +73,9 @@ class Mdm::Event < ApplicationRecord
   #
   # @return [Hash]
   if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-    serialize :info, coder: MetasploitDataModels::Base64Serializer.new
+    serialize :info, coder: MetasploitDataModels::Base64Serializer.new(coerce: true)
   else
-    serialize :info, MetasploitDataModels::Base64Serializer.new
+    serialize :info, MetasploitDataModels::Base64Serializer.new(coerce: true)
   end
 
   #

--- a/app/models/mdm/listener.rb
+++ b/app/models/mdm/listener.rb
@@ -70,9 +70,9 @@ class Mdm::Listener < ApplicationRecord
   #
   # @return [Hash]
   if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-    serialize :options, coder: MetasploitDataModels::Base64Serializer.new
+    serialize :options, coder: MetasploitDataModels::Base64Serializer.new(coerce: true)
   else
-    serialize :options, MetasploitDataModels::Base64Serializer.new
+    serialize :options, MetasploitDataModels::Base64Serializer.new(coerce: true)
   end
 
   #

--- a/app/models/mdm/session.rb
+++ b/app/models/mdm/session.rb
@@ -173,9 +173,9 @@ class Mdm::Session < ApplicationRecord
   #
 
   if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-    serialize :datastore, coder: ::MetasploitDataModels::Base64Serializer.new
+    serialize :datastore, coder: ::MetasploitDataModels::Base64Serializer.new(coerce: true)
   else
-    serialize :datastore, ::MetasploitDataModels::Base64Serializer.new
+    serialize :datastore, ::MetasploitDataModels::Base64Serializer.new(coerce: true)
   end
 
   # Returns whether the session can be upgraded to a meterpreter session from a shell session on Windows.

--- a/app/models/mdm/task.rb
+++ b/app/models/mdm/task.rb
@@ -131,27 +131,27 @@ class Mdm::Task < ApplicationRecord
   #
   # @return [Hash]
   if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-    serialize :options, coder: MetasploitDataModels::Base64Serializer.new
+    serialize :options, coder: MetasploitDataModels::Base64Serializer.new(coerce: true)
   else
-    serialize :options, MetasploitDataModels::Base64Serializer.new
+    serialize :options, MetasploitDataModels::Base64Serializer.new(coerce: true)
   end
 
   # Result of task running.
   #
   # @return [Hash]
   if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-    serialize :result, coder: MetasploitDataModels::Base64Serializer.new
+    serialize :result, coder: MetasploitDataModels::Base64Serializer.new(coerce: true)
   else
-    serialize :result, MetasploitDataModels::Base64Serializer.new
+    serialize :result, MetasploitDataModels::Base64Serializer.new(coerce: true)
   end
 
   # Settings used to configure this task outside of the {#options module options}.
   #
   # @return [Hash]
   if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-    serialize :settings, coder: MetasploitDataModels::Base64Serializer.new
+    serialize :settings, coder: MetasploitDataModels::Base64Serializer.new(coerce: true)
   else
-    serialize :settings, MetasploitDataModels::Base64Serializer.new
+    serialize :settings, MetasploitDataModels::Base64Serializer.new(coerce: true)
   end
 
   #

--- a/app/models/mdm/web_vuln.rb
+++ b/app/models/mdm/web_vuln.rb
@@ -142,9 +142,9 @@ class Mdm::WebVuln < ApplicationRecord
   #
   #   @return [Array<Array(String, String)>] Array of parameter key value pairs
   if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR >= 1
-    serialize :params, coder: MetasploitDataModels::Base64Serializer.new(:default => DEFAULT_PARAMS)
+    serialize :params, coder: MetasploitDataModels::Base64Serializer.new(default: DEFAULT_PARAMS)
   else
-    serialize :params, MetasploitDataModels::Base64Serializer.new(:default => DEFAULT_PARAMS)
+    serialize :params, MetasploitDataModels::Base64Serializer.new(default: DEFAULT_PARAMS)
   end
 
   #


### PR DESCRIPTION
This PR changes the handling of the data that is being passed to the `dump` method.
This aims to fix an issue where `nil` would be forcefully coerced to an empty string, breaking code that would rely on nil values in Pro.

## Testing

- Point Pro & Framework at this branch
- Run the session tests in Pro
- Passing CI