### PR TITLE
Updates the notes model to now validate data is a Hash

### DIFF
--- a/app/models/mdm/note.rb
+++ b/app/models/mdm/note.rb
@@ -113,6 +113,12 @@ class Mdm::Note < ApplicationRecord
     serialize :data, ::MetasploitDataModels::Base64Serializer.new
   end
 
+  #
+  # Validations
+  #
+
+  validate :data_is_hash
+
   private
 
   # {Mdm::Host::OperatingSystemNormalization#normalize_os Normalizes the host operating system} if the note is a
@@ -125,8 +131,16 @@ class Mdm::Note < ApplicationRecord
     end
   end
 
+  # Handles validation to ensure the `data` attribute is of class Hash. If `data` is not a `Hash`, an error is added to
+  # the `data` attribute, which prevents the record from being saved.
+  #
+  # @return [void]
+  # @raise [ActiveRecord::RecordInvalid] if `data` is not a Hash
+  def data_is_hash
+    errors.add(:data, 'must be a Hash') unless data.is_a?(Hash)
+  end
+
   public
 
   Metasploit::Concern.run(self)
 end
-


### PR DESCRIPTION
Related to the:
- https://github.com/rapid7/metasploit-framework/issues/19874
- https://github.com/rapid7/metasploit-framework/pull/19939

This PR updates the notes model to now validate the data attribute is a Hash.

Will need to be tested in conjunction with https://github.com/rapid7/metasploit-framework/pull/19939

Can be tested by pointing the Framework Gemfile at this PR: `gem 'metasploit_data_models', git: 'https://github.com/cgranleese-r7/metasploit_data_models', branch: 'adds-data-validation-to-notes-model'`

## Verification
- [ ] Code review
- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/mssql/mssql_enum` (or any module that has been updated)
- [ ] **Verify** the module works as expected when a Hash is passed into the data attribute
- [ ] **Verify** the module now returns an error when a Hash is not passed into the data attribute