### PR TITLE
Manual version bump as automatic one failed last time

### DIFF
--- a/lib/metasploit_data_models/version.rb
+++ b/lib/metasploit_data_models/version.rb
@@ -1,6 +1,6 @@
 module MetasploitDataModels
   # VERSION is managed by GemRelease
-  VERSION = '6.0.6'
+  VERSION = '6.0.7'
 
   # @return [String]
   #


### PR DESCRIPTION
Manual version bump as automatic one failed last time
version 6.0.6 already exists in rubygems https://rubygems.org/gems/metasploit_data_models/versions/6.0.6