### PR TITLE
Updates workflow to run against rails versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,6 +50,9 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+        rails:
+          - '~> 7.0.0'
+          - '~> 7.1.0'
         os:
           - ubuntu-20.04
           - ubuntu-latest
@@ -60,7 +63,7 @@ jobs:
     env:
       RAILS_ENV: test
 
-    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
+    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - Rails ${{ matrix.rails }}
     steps:
       - name: Install system dependencies
         run: sudo apt-get install libpcap-dev graphviz
@@ -73,6 +76,12 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+
+      - name: Update Rails version
+        run: |
+          ruby -pi.bak -e "gsub(/gem ['\"]rails['\"],\s*['\"].+['\"]?/, \"gem 'rails', '${{ matrix.rails }}'\")" Gemfile
+          bundle update
+          bundle install
 
       - name: Test
         run: |


### PR DESCRIPTION
This PR updates the [verify.yml](https://github.com/rapid7/metasploit_data_models/compare/master...cgranleese-r7:metasploit_data_models:update-workflow-to-run-against-rails-versions?expand=1#diff-b32b798d8ec577b859922a84b90dfe871b19fad404cc6fa7a6fe163f079fbcbf) workflow to now be tested against a matrix of Rails versions.

## Verification
- [ ] CI goes green
- [ ] Code changes are sane