### PR TITLE
Bump ubuntu version in verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -54,7 +54,7 @@ jobs:
           - '~> 7.0.0'
           - '~> 7.1.0'
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-latest
         exclude:
           - { os: ubuntu-latest, ruby: '2.7' }


### PR DESCRIPTION
Version 20.04 is being dropped from Github's official support:
> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

The tests were failling on: https://github.com/rapid7/metasploit_data_models/pull/208 which prompted this fix.

# Verification 
- [ ] Ensure tests pass