### PR TITLE
Updates verify workflow to use shared pipeline

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,71 +25,14 @@ on:
       - '*'
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
-
-    services:
-      postgres:
-        image: postgres:9.6
-        ports: ["5432:5432"]
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    strategy:
-      fail-fast: true
-      matrix:
-        ruby:
-          - '2.7'
-          - '3.0'
-          - '3.1'
-          - '3.2'
-        rails:
-          - '~> 7.0.0'
-          - '~> 7.1.0'
-        os:
-          - ubuntu-22.04
-          - ubuntu-latest
-        exclude:
-          - { os: ubuntu-latest, ruby: '2.7' }
-          - { os: ubuntu-latest, ruby: '3.0' }
-
-    env:
-      RAILS_ENV: test
-
-    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - Rails ${{ matrix.rails }}
-    steps:
-      - name: Install system dependencies
-        run: sudo apt-get install libpcap-dev graphviz
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Update Rails version
-        run: |
-          ruby -pi.bak -e "gsub(/gem ['\"]rails['\"],\s*['\"].+['\"]?/, \"gem 'rails', '${{ matrix.rails }}'\")" Gemfile
-          bundle update
-          bundle install
-
-      - name: Test
-        run: |
-          cp spec/dummy/config/database.yml.github_actions spec/dummy/config/database.yml
-          bundle exec rake --version
-          bundle exec rake db:create db:migrate
-
-          # Disabling this check because it is proving unreliable
-          # git diff --exit-code spec/dummy/db/structure.sql
-          bundle exec rake spec
-          bundle exec rake yard
+  build:
+    uses: rapid7/metasploit-framework/.github/workflows/shared_gem_verify_rails.yml@master
+    with:
+      dependencies: '["libpcap-dev", "graphviz"]'
+      test_commands: |
+        cp spec/dummy/config/database.yml.github_actions spec/dummy/config/database.yml
+        bundle exec rake --version
+        bundle exec rake db:create db:migrate
+        bundle exec rake spec
+        bundle exec rake spec
+        bundle exec rake yard

--- a/metasploit_data_models.gemspec
+++ b/metasploit_data_models.gemspec
@@ -46,6 +46,15 @@ Gem::Specification.new do |s|
   # arel-helpers: Useful tools to help construct database queries with ActiveRecord and Arel.
   s.add_runtime_dependency 'arel-helpers'
 
+  # Standard libraries: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
+  %w[
+    bigdecimal
+    drb
+    mutex_m
+  ].each do |library|
+    s.add_runtime_dependency library
+  end
+
   if RUBY_PLATFORM =~ /java/
     # markdown formatting for yard
     s.add_development_dependency 'kramdown'


### PR DESCRIPTION
This updates this workflow to make use off the shared pipeline added as part of https://github.com/rapid7/metasploit-framework/pull/20001.

Initially this PR will point at these new pipelines on my @cgranleese-r7 repository for testing. Once this is landed, I will rebase this PR.

Related PRs:
- https://github.com/rapid7/metasploit-framework/pull/20001
- https://github.com/rapid7/metasploit-concern/pull/45
- https://github.com/rapid7/metasploit-credential/pull/189
- https://github.com/rapid7/metasploit-model/pull/73
- https://github.com/rapid7/metasploit_data_models/pull/216
- https://github.com/rapid7/rex-core/pull/43
- https://github.com/rapid7/rex-exploitation/pull/46/
- https://github.com/rapid7/rex-mime/pull/9
- https://github.com/rapid7/rex-powershell/pull/45
- https://github.com/rapid7/rex-random_identifier/pull/15
- https://github.com/rapid7/rex-socket/pull/73
- https://github.com/rapid7/rex-sslscan/pull/10
- https://github.com/rapid7/rex-text/pull/73

## Ruby 3.4
I also added bigdecimal, drb and mutex_m  to the gemspec as it is not part of the default gems starting from Ruby 3.4.0(https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/). This can be pulled out into another PR if that is preferred.

## Verification

- [ ] Ensure CI passes
- [ ] Testing output flows as expected