### PR TITLE
Add checkcode details to vuln attempt

### DIFF
--- a/app/models/mdm/vuln_attempt.rb
+++ b/app/models/mdm/vuln_attempt.rb
@@ -63,6 +63,20 @@ class Mdm::VulnAttempt < ApplicationRecord
   #
   #   @return [String]
 
+  # @!attribute check_code
+  #   The check code returned by the module's check method, if this attempt
+  #   was a vulnerability check rather than an exploitation attempt.
+  #
+  #   @return [String] one of 'vulnerable', 'appears', 'safe', 'detected', 'unknown'
+  #   @return [nil] if this was an exploitation attempt, not a check
+
+  # @!attribute check_detail
+  #   The human-readable message from the module's check method describing
+  #   why the target was determined to be vulnerable, safe, etc.
+  #
+  #   @return [String] if {#check_code} is present.
+  #   @return [nil] if this was an exploitation attempt, not a check
+
   # @!attribute username
   #   The {Mdm::User#username name of the user} that made this attempt.
   #

--- a/db/migrate/20260411000000_add_check_code_to_vuln_attempts.rb
+++ b/db/migrate/20260411000000_add_check_code_to_vuln_attempts.rb
@@ -1,0 +1,6 @@
+class AddCheckCodeToVulnAttempts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :vuln_attempts, :check_code, :string
+    add_column :vuln_attempts, :check_detail, :text
+  end
+end

--- a/spec/app/models/mdm/vuln_attempt_spec.rb
+++ b/spec/app/models/mdm/vuln_attempt_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Mdm::VulnAttempt, type: :model do
       it { is_expected.to have_db_column(:session_id).of_type(:integer) }
       it { is_expected.to have_db_column(:loot_id).of_type(:integer) }
       it { is_expected.to have_db_column(:fail_detail).of_type(:text) }
+      it { is_expected.to have_db_column(:check_code).of_type(:string) }
+      it { is_expected.to have_db_column(:check_detail).of_type(:text) }
     end
   end
 

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -1755,7 +1755,9 @@ CREATE TABLE public.vuln_attempts (
     module text,
     session_id integer,
     loot_id integer,
-    fail_detail text
+    fail_detail text,
+    check_code character varying,
+    check_detail text
 );
 
 
@@ -3602,6 +3604,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250721114306'),
 ('20251231162000'),
 ('20260130124052'),
+('20260411000000'),
 ('21'),
 ('22'),
 ('23'),


### PR DESCRIPTION
Needed by https://github.com/rapid7/metasploit-framework/pull/21307

Add check code details to the VulnAttempt model, so that these can be shown to the user:

```
msf > vulns -v

Vulnerabilities
===============
  0. Vuln ID: 10
     Timestamp: 2026-04-15 00:05:25 UTC
     Host: 10.140.113.233
     Name: ElasticSearch Snapshot API Directory Traversal
     References: CVE-2015-5531,PACKETSTORM-132721
     Information: Vulnerability confirmed by check of auxiliary/scanner/http/elasticsearch_traversal.
     Resource: {}
     Service:
     Vuln attempts:
     0. ID: 28
        Vuln ID: 10
        Timestamp: 2026-04-15 00:05:25 UTC
        Exploit: false
        Fail reason: none
        Username: foo
        Module: auxiliary/scanner/http/elasticsearch_traversal
        Session ID: nil
        Loot ID: nil
        Fail Detail: nil
        Check Code: appears
        Check Detail: Successfully created snapshot repositories, suggesting the Snapshot API is vulnerable to CVE-2015-5531.
```