### PR TITLE
Add Callback Address column to Listener

### DIFF
--- a/app/models/mdm/listener.rb
+++ b/app/models/mdm/listener.rb
@@ -21,7 +21,16 @@ class Mdm::Listener < ApplicationRecord
   #
 
   # @!attribute address
-  #   The IP address to which the listener is bound.
+  #   The local IP address to which the listener is bound (used as the
+  #   handler's +ReverseListenerBindAddress+).
+  #
+  #   @return [String]
+
+  # @!attribute callback_address
+  #   The IP address or hostname the payload connects back to (used as the
+  #   handler's +LHOST+).  This is the address that must be routable from the
+  #   target and may differ from {#address} when NAT or port forwarding is in
+  #   use.
   #
   #   @return [String]
 

--- a/db/migrate/20260728000000_add_callback_address_to_listeners.rb
+++ b/db/migrate/20260728000000_add_callback_address_to_listeners.rb
@@ -1,0 +1,5 @@
+class AddCallbackAddressToListeners < ActiveRecord::Migration[7.0]
+  def change
+    add_column :listeners, :callback_address, :text
+  end
+end

--- a/spec/app/models/mdm/listener_spec.rb
+++ b/spec/app/models/mdm/listener_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Mdm::Listener, type: :model do
       it { is_expected.to have_db_column(:owner).of_type(:text) }
       it { is_expected.to have_db_column(:payload).of_type(:text) }
       it { is_expected.to have_db_column(:address).of_type(:text) }
+      it { is_expected.to have_db_column(:callback_address).of_type(:text) }
       it { is_expected.to have_db_column(:port).of_type(:integer) }
       it { is_expected.to have_db_column(:options).of_type(:binary) }
       it { is_expected.to have_db_column(:macro).of_type(:text) }

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -561,7 +561,8 @@ CREATE TABLE public.listeners (
     address text,
     port integer,
     options bytea,
-    macro text
+    macro text,
+    callback_address text
 );
 
 
@@ -3605,6 +3606,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20251231162000'),
 ('20260130124052'),
 ('20260411000000'),
+('20260728000000'),
 ('21'),
 ('22'),
 ('23'),


### PR DESCRIPTION
This PR adds an additional column to the listener.
This allows for decoupling the listener address and the LHOST value in multi/handler in Framework and Pro.

I think the tests have failed due to a Rails version warning and not due to this change?
```
Finished in 7.67 seconds (files took 2.36 seconds to load)
1738 examples, 0 failures, 3 pending
```
Seems like it's the coverage options that are causing CI to fail